### PR TITLE
[MAPLE] [VERIFYME] Add the correct mixer_paths for 8998-tasha sound card

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.    -->
+<!--                                                                        -->
+<!-- Redistribution and use in source and binary forms, with or without     -->
+<!-- modification, are permitted provided that the following conditions are -->
+<!-- met:                                                                   -->
+<!--     * Redistributions of source code must retain the above copyright   -->
+<!--       notice, this list of conditions and the following disclaimer.    -->
+<!--     * Redistributions in binary form must reproduce the above          -->
+<!--       copyright notice, this list of conditions and the following      -->
+<!--       disclaimer in the documentation and/or other materials provided  -->
+<!--       with the distribution.                                           -->
+<!--     * Neither the name of The Linux Foundation nor the names of its    -->
+<!--       contributors may be used to endorse or promote products derived  -->
+<!--       from this software without specific prior written permission.    -->
+<!--                                                                        -->
+<!-- THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED           -->
+<!-- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF   -->
+<!-- MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT -->
+<!-- ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS -->
+<!-- BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR -->
+<!-- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   -->
+<!-- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR        -->
+<!-- BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,  -->
+<!-- OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN -->
+<!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          -->
 <mixer>
     <!-- These are the initial mixer settings -->
     <ctl name="Voice Rx Device Mute" id="0" value="0" />
@@ -35,15 +60,6 @@
     <ctl name="RX6 Digital Volume" value="84" />
     <ctl name="RX7 Digital Volume" value="84" />
     <ctl name="RX8 Digital Volume" value="84" />
-    <ctl name="RX0 Mix Digital Volume" value="84" />
-    <ctl name="RX1 Mix Digital Volume" value="84" />
-    <ctl name="RX2 Mix Digital Volume" value="84" />
-    <ctl name="RX3 Mix Digital Volume" value="84" />
-    <ctl name="RX4 Mix Digital Volume" value="84" />
-    <ctl name="RX5 Mix Digital Volume" value="84" />
-    <ctl name="RX6 Mix Digital Volume" value="84" />
-    <ctl name="RX7 Mix Digital Volume" value="84" />
-    <ctl name="RX8 Mix Digital Volume" value="84" />
     <ctl name="ADC1 Volume" value="12" />
     <ctl name="ADC2 Volume" value="12" />
     <ctl name="ADC3 Volume" value="0" />
@@ -61,12 +77,23 @@
     <ctl name="DEC8 Volume" value="84" />
     <ctl name="COMP1 Switch" value="1" />
     <ctl name="COMP2 Switch" value="1" />
-    <ctl name="COMP7 Switch" value="1" />
-    <ctl name="COMP8 Switch" value="1" />
+    <ctl name="COMP7 Switch" value="0" />
+    <ctl name="COMP8 Switch" value="0" />
     <ctl name="RX HPH Mode" value="CLS_H_HIFI" />
     <ctl name="SLIMBUS_3_RX Port Mixer MI2S_TX" value="0" />
-    <ctl name="HDMI_RX Port Mixer MI2S_TX" value="0" />
     <ctl name="SLIMBUS_0_RX Port Mixer SLIM_0_TX" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia7" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia10" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia11" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia12" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia13" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia14" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia15" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="SLIMBUS_6_RX Port Mixer SLIM_0_TX" value="0" />
     <ctl name="AUX_PCM_RX Audio Mixer MultiMedia1" value="0" />
     <ctl name="AUX_PCM_RX Audio Mixer MultiMedia4" value="0" />
     <ctl name="AUX_PCM_RX Audio Mixer MultiMedia5" value="0" />
@@ -82,8 +109,8 @@
     <ctl name="SLIMBUS_4_RX Audio Mixer MultiMedia2" value="0" />
     <ctl name="MultiMedia5 Mixer SLIM_0_TX" value="0" />
     <ctl name="MultiMedia5 Mixer AFE_PCM_TX" value="0" />
-    <ctl name="MultiMedia5 Mixer TERT_MI2S_TX" value="0" />
-    <ctl name="MultiMedia5 Mixer AUX_PCM_UL_TX" value="0" />
+    <ctl name="MultiMedia5 Mixer SLIM_8_TX" value="0" />
+    <ctl name="MultiMedia5 Mixer SLIM_7_TX" value="0" />
     <ctl name="MultiMedia4 Mixer MI2S_TX" value="0" />
     <ctl name="MultiMedia1 Mixer MI2S_TX" value="0" />
     <ctl name="MultiMedia7 Mixer MI2S_TX" value="0" />
@@ -96,13 +123,14 @@
     <ctl name="MultiMedia16 Mixer MI2S_TX" value="0" />
     <ctl name="MultiMedia1 Mixer SLIM_0_TX" value="0" />
     <ctl name="MultiMedia1 Mixer SLIM_4_TX" value="0" />
-    <ctl name="MultiMedia1 Mixer AUX_PCM_UL_TX" value="0" />
+    <ctl name="MultiMedia1 Mixer SLIM_7_TX" value="0" />
     <ctl name="HDMI Mixer MultiMedia1" value="0" />
     <ctl name="HDMI Mixer MultiMedia2" value="0" />
     <ctl name="HDMI Mixer MultiMedia3" value="0" />
     <ctl name="HDMI Mixer MultiMedia4" value="0" />
     <ctl name="HDMI Mixer MultiMedia5" value="0" />
     <ctl name="HDMI Mixer MultiMedia7" value="0" />
+    <ctl name="HDMI Mixer MultiMedia9" value="0" />
     <ctl name="HDMI Mixer MultiMedia10" value="0" />
     <ctl name="HDMI Mixer MultiMedia11" value="0" />
     <ctl name="HDMI Mixer MultiMedia12" value="0" />
@@ -110,28 +138,73 @@
     <ctl name="HDMI Mixer MultiMedia14" value="0" />
     <ctl name="HDMI Mixer MultiMedia15" value="0" />
     <ctl name="HDMI Mixer MultiMedia16" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia1" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia2" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia3" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia4" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia5" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia6" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia7" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia8" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia9" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia10" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia11" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia12" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia13" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia14" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia15" value="0" />
+    <ctl name="DISPLAY_PORT Mixer MultiMedia16" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia1" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia2" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia2" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia3" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia3" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia4" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia4" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia5" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia7" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia7" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia7" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia10" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia10" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia10" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia11" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia11" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia11" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia12" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia12" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia12" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia13" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia13" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia13" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia14" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia14" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia14" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia15" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia15" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia15" value="0" />
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia16" value="0" />
     <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia2" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia3" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia7" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia10" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia11" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia12" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia13" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia14" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia15" value="0" />
+    <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia16" value="0" />
+    <ctl name="MultiMedia1 Mixer USB_AUDIO_TX" value="0" />
+    <ctl name="MultiMedia5 Mixer USB_AUDIO_TX" value="0" />
+    <ctl name="MultiMedia8 Mixer USB_AUDIO_TX" value="0" />
     <ctl name="MultiMedia6 Mixer SLIM_0_TX" value="0" />
     <ctl name="IIR0 INP0 MUX" value="ZERO" />
     <ctl name="IIR0 INP1 MUX" value="ZERO" />
@@ -268,9 +341,12 @@
     <ctl name="SLIM_0_TX Channels" value="One" />
     <ctl name="SLIM_1_TX Channels" value="One" />
     <ctl name="SLIM RX0 MUX" value="ZERO" />
+    <ctl name="SLIM RX2 MUX" value="ZERO" />
     <ctl name="SLIM RX3 MUX" value="ZERO" />
     <ctl name="SLIM RX4 MUX" value="ZERO" />
+    <ctl name="SLIM RX5 MUX" value="ZERO" />
     <ctl name="EAR PA Gain" value="G_6_DB" />
+    <ctl name="EAR SPKR PA Gain" value="G_DEFAULT" />
     <ctl name="SpkrLeft COMP Switch" value="0" />
     <ctl name="SpkrRight COMP Switch" value="0" />
     <ctl name="SpkrLeft BOOST Switch" value="0" />
@@ -290,7 +366,16 @@
     <ctl name="AIF1_CAP Mixer SLIM TX1" value="0"/>
     <ctl name="AIF1_CAP Mixer SLIM TX0" value="0"/>
     <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="SLIMBUS_6_RX Port Mixer AUX_PCM_UL_TX" value="0" />
     <ctl name="HDMI Mixer MultiMedia4" value="0" />
+    <ctl name= "RX INT1_1 NATIVE MUX" value="OFF" />
+    <ctl name= "RX INT2_1 NATIVE MUX" value="OFF" />
+    <ctl name= "RX INT3_1 NATIVE MUX" value="OFF" />
+    <ctl name= "RX INT4_1 NATIVE MUX" value="OFF" />
+    <!-- HFP start -->
+    <ctl name="HFP_PRI_AUX_UL_HL Switch" value="0" />
+    <ctl name="SLIMBUS_0_RX Port Mixer SLIM_7_TX" value="0" />
+    <!-- HFP end -->
     <!-- echo reference -->
     <ctl name="AUDIO_REF_EC_UL1 MUX" value="None" />
     <!-- usb headset -->
@@ -308,76 +393,45 @@
     <ctl name="AFE_PCM_RX Audio Mixer MultiMedia5" value="0" />
     <!-- usb headset end -->
     <!-- fm -->
-    <ctl name="SLIMBUS_0_RX Port Mixer TERT_MI2S_TX" value="0" />
+    <ctl name="SLIMBUS_8 LOOPBACK Volume" value="0" />
+    <ctl name="SLIMBUS_0_RX Port Mixer SLIM_8_TX" value="0" />
     <ctl name="SLIMBUS_DL_HL Switch" value="0" />
-    <ctl name="MultiMedia1 Mixer TERT_MI2S_TX" value="0" />
-    <ctl name="MultiMedia2 Mixer TERT_MI2S_TX" value="0" />
+    <ctl name="SLIMBUS_6_RX Port Mixer SLIM_8_TX" value="0" />
+    <ctl name="SLIMBUS6_DL_HL Switch" value="0" />
+    <ctl name="MultiMedia1 Mixer SLIM_8_TX" value="0" />
+    <ctl name="MultiMedia2 Mixer SLIM_8_TX" value="0" />
     <!-- fm end -->
-
-    <!-- Voice -->
-    <ctl name="SLIM_0_RX_Voice Mixer CSVoice" value="0" />
-    <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="0" />
-    <!-- Voice HDMI -->
-    <ctl name="HDMI_RX_Voice Mixer CSVoice" value="0" />
-    <!-- Voice BTSCO -->
-    <ctl name="AUX PCM SampleRate" value="8000" />
-    <ctl name="AUX_PCM_RX_Voice Mixer CSVoice" value="0" />
-    <ctl name="Voice_Tx Mixer AUX_PCM_TX_Voice" value="0" />
-    <!-- Voice USB headset -->
-    <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="0" />
-    <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="0" />
-    <!-- Voice end-->
-
-    <!-- Voice2 -->
-    <ctl name="SLIM_0_RX_Voice Mixer Voice2" value="0" />
-    <ctl name="Voice2_Tx Mixer SLIM_0_TX_Voice2" value="0" />
-    <!-- Voice2 HDMI -->
-    <ctl name="HDMI_RX_Voice Mixer Voice2" value="0" />
-    <!-- Voice2 BTSCO -->
-    <ctl name="AUX_PCM_RX_Voice Mixer Voice2" value="0" />
-    <ctl name="Voice2_Tx Mixer AUX_PCM_TX_Voice2" value="0" />
-    <!-- Voice2 USB headset -->
-    <ctl name="AFE_PCM_RX_Voice Mixer Voice2" value="0" />
-    <ctl name="Voice2_Tx Mixer AFE_PCM_TX_Voice2" value="0" />
-    <!-- Voice2 end-->
-
-    <!-- VoLTE -->
-    <ctl name="SLIM_0_RX_Voice Mixer VoLTE" value="0" />
-    <ctl name="VoLTE_Tx Mixer SLIM_0_TX_VoLTE" value="0" />
-    <!-- VoLTE HDMI -->
-    <ctl name="HDMI_RX_Voice Mixer VoLTE" value="0" />
-    <!-- VoLTE BTSCO -->
-    <ctl name="AUX_PCM_RX_Voice Mixer VoLTE" value="0" />
-    <ctl name="VoLTE_Tx Mixer AUX_PCM_TX_VoLTE" value="0" />
-    <!-- VoLTE USB headset -->
-    <ctl name="AFE_PCM_RX_Voice Mixer VoLTE" value="0" />
-    <ctl name="VoLTE_Tx Mixer AFE_PCM_TX_VoLTE" value="0" />
-    <!-- VoLTE end-->
 
     <!-- Multimode Voice1 -->
     <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode1" value="0" />
+    <ctl name="SLIM_6_RX_Voice Mixer VoiceMMode1" value="0" />
     <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="0" />
     <!-- Multimode Voice1 HDMI -->
     <ctl name="HDMI_RX_Voice Mixer VoiceMMode1" value="0" />
     <!-- Multimode Voice1 BTSCO -->
-    <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode1" value="0" />
-    <ctl name="VoiceMMode1_Tx Mixer AUX_PCM_TX_MMode1" value="0" />
+    <ctl name="SLIM_7_RX_Voice Mixer VoiceMMode1" value="0" />
+    <ctl name="VoiceMMode1_Tx Mixer SLIM_7_TX_MMode1" value="0" />
     <!-- Multimode Voice1 USB headset -->
     <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode1" value="0" />
     <ctl name="VoiceMMode1_Tx Mixer AFE_PCM_TX_MMode1" value="0" />
+    <ctl name="USB_AUDIO_RX_Voice Mixer VoiceMMode1" value="0" />
+    <ctl name="VoiceMMode1_Tx Mixer USB_AUDIO_TX_MMode1" value="0" />
     <!-- Miltimode Voice1 end-->
 
     <!-- Multimode Voice2 -->
     <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode2" value="0" />
+    <ctl name="SLIM_6_RX_Voice Mixer VoiceMMode2" value="0" />
     <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="0" />
     <!-- Multimode Voice2 HDMI -->
     <ctl name="HDMI_RX_Voice Mixer VoiceMMode2" value="0" />
     <!-- Multimode Voice2 BTSCO -->
-    <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode2" value="0" />
-    <ctl name="VoiceMMode2_Tx Mixer AUX_PCM_TX_MMode2" value="0" />
+    <ctl name="SLIM_7_RX_Voice Mixer VoiceMMode2" value="0" />
+    <ctl name="VoiceMMode2_Tx Mixer SLIM_7_TX_MMode2" value="0" />
     <!-- Multimode Voice2 USB headset -->
     <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode2" value="0" />
     <ctl name="VoiceMMode2_Tx Mixer AFE_PCM_TX_MMode2" value="0" />
+    <ctl name="USB_AUDIO_RX_Voice Mixer VoiceMMode2" value="0" />
+    <ctl name="VoiceMMode2_Tx Mixer USB_AUDIO_TX_MMode2" value="0" />
     <!-- Multimode Voice2 end-->
 
     <!-- Voice external ec. reference -->
@@ -400,41 +454,39 @@
 
     <!-- Incall Music -->
     <ctl name="Incall_Music Audio Mixer MultiMedia2" value="0" />
-    <ctl name="Incall_Music_2 Audio Mixer MultiMedia9" value="0" />
     <!-- Incall Music End -->
 
     <!-- compress-voip-call start -->
     <ctl name="SLIM_0_RX_Voice Mixer Voip" value="0" />
+    <ctl name="SLIM_6_RX_Voice Mixer Voip" value="0" />
     <ctl name="Voip_Tx Mixer SLIM_0_TX_Voip" value="0" />
-    <ctl name="AUX_PCM_RX_Voice Mixer Voip" value="0" />
-    <ctl name="Voip_Tx Mixer AUX_PCM_TX_Voip" value="0" />
+    <ctl name="SLIM_7_RX_Voice Mixer Voip" value="0" />
+    <ctl name="Voip_Tx Mixer SLIM_7_TX_Voip" value="0" />
     <ctl name="AFE_PCM_RX_Voice Mixer Voip" value="0" />
     <ctl name="Voip_Tx Mixer AFE_PCM_TX_Voip" value="0" />
+    <ctl name="USB_AUDIO_RX_Voice Mixer Voip" value="0" />
+    <ctl name="Voip_Tx Mixer USB_AUDIO_TX_Voip" value="0" />
     <!-- compress-voip-call end-->
-
-    <!-- QCHAT start -->
-    <ctl name="SLIM_0_RX_Voice Mixer QCHAT" value="0" />
-    <ctl name="QCHAT_Tx Mixer SLIM_0_TX_QCHAT" value="0" />
-    <ctl name="AUX_PCM_RX_Voice Mixer QCHAT" value="0" />
-    <ctl name="QCHAT_Tx Mixer AUX_PCM_TX_QCHAT" value="0" />
-    <!-- QCHAT end-->
 
     <!-- VoWLAN start -->
     <ctl name="SLIM_0_RX_Voice Mixer VoWLAN" value="0" />
+    <ctl name="SLIM_6_RX_Voice Mixer VoWLAN" value="0" />
     <ctl name="VoWLAN_Tx Mixer SLIM_0_TX_VoWLAN" value="0" />
     <ctl name="HDMI_RX_Voice Mixer VoWLAN" value="0" />
-    <ctl name="AUX_PCM_RX_Voice Mixer VoWLAN" value="0" />
-    <ctl name="VoWLAN_Tx Mixer AUX_PCM_TX_VoWLAN" value="0" />
+    <ctl name="SLIM_7_RX_Voice Mixer VoWLAN" value="0" />
+    <ctl name="VoWLAN_Tx Mixer SLIM_7_TX_VoWLAN" value="0" />
     <ctl name="AFE_PCM_RX_Voice Mixer VoWLAN" value="0" />
     <ctl name="VoWLAN_Tx Mixer AFE_PCM_TX_VoWLAN" value="0" />
+    <ctl name="USB_AUDIO_RX_Voice Mixer VoWLAN" value="0" />
+    <ctl name="VoWLAN_Tx Mixer USB_AUDIO_TX_VoWLAN" value="0" />
     <!-- VoWLAN end-->
 
     <!-- Audio BTSCO -->
-    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia1" value="0" />
-    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia4" value="0" />
-    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia5" value="0" />
-    <ctl name="AUX_PCM_RX Audio Mixer MultiMedia6" value="0" />
-    <ctl name="MultiMedia1 Mixer AUX_PCM_UL_TX" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia1" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia4" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia5" value="0" />
+    <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia6" value="0" />
+    <ctl name="MultiMedia1 Mixer SLIM_7_TX" value="0" />
     <!-- IIR/voice anc -->
     <ctl name="IIR0 Band1" id ="0" value="268435456" />
     <ctl name="IIR0 Band1" id ="1" value="0" />
@@ -501,13 +553,16 @@
     <ctl name="IIR1 INP0 Volume" value="54" />
     <!-- IIR/voice anc end -->
     <!-- handset -->
-    <ctl name="PM8996_Ear_Enable_States" value="Disable" />
+    <ctl name="Ear_Enable_States" value="Disable" />
     <!-- handset end -->
     <!-- anc handset -->
     <ctl name="ANC Slot" value="0" />
     <ctl name="ANC0 FB MUX" value="ZERO" />
     <ctl name="ANC1 FB MUX" value="ZERO" />
     <ctl name="ANC EAR Enable Switch" value="0" />
+    <ctl name="ANC OUT EAR SPKR Enable Switch" value="0" />
+    <ctl name="ANC SPKR PA Enable Switch" value="0" />
+    <ctl name="SpkrLeft WSA PA Gain" value="G_0_DB" />
     <!-- anc handset end -->
     <ctl name="ANC Function" value="OFF" />
     <ctl name="ANC HPHL Enable Switch" value="0" />
@@ -529,7 +584,7 @@
     <!-- vbat related data end-->
     <!-- audio record compress-->
     <ctl name="MultiMedia8 Mixer SLIM_0_TX" value="0" />
-    <ctl name="MultiMedia8 Mixer AUX_PCM_UL_TX" value="0" />
+    <ctl name="MultiMedia8 Mixer SLIM_7_TX" value="0" />
     <ctl name="MultiMedia8 Mixer AFE_PCM_TX" value="0" />
     <!-- audio record compress end-->
     <!-- listen -->
@@ -543,20 +598,24 @@
     <ctl name="LSM8 MUX" value="None" />
     <ctl name="SLIMBUS_5_TX LSM Function" value="None" />
     <!-- listen end-->
+    <!-- split a2dp -->
+    <ctl name="BT SampleRate" value="KHZ_8" />
+    <ctl name="AFE Input Channels" value="Zero" />
+    <ctl name="SLIM7_RX ADM Channels" value="Zero" />
+    <!-- split a2dp end-->
 
     <!-- ADSP testfwk -->
     <ctl name="SLIMBUS_DL_HL Switch" value="0" />
+    <ctl name="SLIMBUS6_DL_HL Switch" value="0" />
     <!-- ADSP testfwk end-->
 
-    <!-- Speaker Reverse -->
-    <ctl name="Set Custom Stereo OnOff" value="0" />
-    <!-- Speaker Reverse end -->
+    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia3" value="0" />
+
+    <ctl name="LDO_H Enable" value="0"/>
 
     <!-- Speaker reverse, mono -->
     <ctl name="Set Custom Stereo" value="Off" />
     <!-- Speaker reverse, mono end -->
-
-    <ctl name="AFE_PCM_RX Audio Mixer MultiMedia3" value="0" />
 
     <!-- Stereo Rec -->
     <ctl name="SLIM_0_TX Format" value="S16_LE" />
@@ -567,23 +626,28 @@
     <ctl name="RX INT2_1 HPF cut off" value="CF_NEG_3DB_0P48HZ" />
     <!-- Rx HPF end -->
 
-    <ctl name="LDO_H Enable" value="0"/>
-
     <!-- These are audio route (FE to BE) specific mixer settings -->
     <path name="gsm-mode">
         <ctl name="GSM mode Enable" value="ON" />
     </path>
 
     <path name="echo-reference speaker-vbat-mono">
-        <ctl name="VOC_EXT_EC MUX" value="SLIM_1_TX" />
         <ctl name="AIF3_CAP Mixer SLIM TX1" value="1" />
         <ctl name="SLIM TX1 MUX" value="RX_MIX_TX1" />
         <ctl name="RX MIX TX1 MUX" value="RX_MIX_VBAT7" />
         <ctl name="SLIM_1_TX Channels" value="One" />
+        <ctl name="VOC_EXT_EC MUX" value="SLIM_1_TX" />
+   </path>
+
+    <path name="echo-reference speaker-vbat-mono-2">
+        <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
+        <ctl name="SLIM TX2 MUX" value="RX_MIX_TX2" />
+        <ctl name="RX MIX TX2 MUX" value="RX_MIX_VBAT8" />
+        <ctl name="SLIM_1_TX Channels" value="One" />
+        <ctl name="VOC_EXT_EC MUX" value="SLIM_1_TX" />
    </path>
 
    <path name="echo-reference speaker-vbat">
-        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_1_TX" />
         <ctl name="AIF3_CAP Mixer SLIM TX1" value="1" />
         <ctl name="AIF3_CAP Mixer SLIM TX2" value="1" />
         <ctl name="SLIM TX1 MUX" value="RX_MIX_TX1" />
@@ -591,6 +655,7 @@
         <ctl name="RX MIX TX1 MUX" value="RX_MIX_VBAT7" />
         <ctl name="RX MIX TX2 MUX" value="RX_MIX_VBAT8" />
         <ctl name="SLIM_1_TX Channels" value="Two" />
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_1_TX" />
     </path>
 
     <path name="echo-reference">
@@ -598,7 +663,7 @@
     </path>
 
     <path name="echo-reference headphones">
-        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_RX" />
+        <ctl name="AUDIO_REF_EC_UL1 MUX" value="SLIM_6_RX" />
     </path>
 
     <path name="echo-reference headphones-44.1">
@@ -609,8 +674,16 @@
         <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia1" value="1" />
     </path>
 
+    <path name="deep-buffer-playback speaker-protected">
+        <path name="deep-buffer-playback" />
+    </path>
+
     <path name="deep-buffer-playback hdmi">
         <ctl name="HDMI Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia1" value="1" />
     </path>
 
     <path name="deep-buffer-playback speaker-and-hdmi">
@@ -618,13 +691,17 @@
         <path name="deep-buffer-playback" />
     </path>
 
+    <path name="deep-buffer-playback speaker-and-display-port">
+        <path name="deep-buffer-playback display-port" />
+        <path name="deep-buffer-playback" />
+    </path>
+
     <path name="deep-buffer-playback bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia1" value="1" />
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia1" value="1" />
     </path>
 
     <path name="deep-buffer-playback bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="deep-buffer-playback bt-sco" />
     </path>
 
@@ -633,7 +710,11 @@
     </path>
 
     <path name="deep-buffer-playback usb-headphones">
-        <path name="deep-buffer-playback afe-proxy" />
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia1" value="1" />
     </path>
 
     <path name="deep-buffer-playback speaker-and-usb-headphones">
@@ -642,6 +723,11 @@
     </path>
 
     <path name="deep-buffer-playback headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback speaker-and-headphones">
+        <path name="deep-buffer-playback headphones" />
         <path name="deep-buffer-playback" />
     </path>
 
@@ -653,7 +739,15 @@
     </path>
 
     <path name="deep-buffer-playback incall-music-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="deep-buffer-playback incall-music" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music-usb-headphones">
+        <path name="deep-buffer-playback incall-music" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music-usb-headset">
         <path name="deep-buffer-playback incall-music" />
     </path>
 
@@ -665,7 +759,15 @@
     </path>
 
     <path name="deep-buffer-playback incall-music2-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="deep-buffer-playback incall-music2" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music2-usb-headphones">
+        <path name="deep-buffer-playback incall-music2" />
+    </path>
+
+    <path name="deep-buffer-playback incall-music2-usb-headset">
         <path name="deep-buffer-playback incall-music2" />
     </path>
 
@@ -673,17 +775,24 @@
         <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia5" value="1" />
     </path>
 
+    <path name="low-latency-playback speaker-protected">
+        <path name="low-latency-playback" />
+    </path>
+
     <path name="low-latency-playback hdmi">
         <ctl name="HDMI Mixer MultiMedia5" value="1" />
     </path>
 
+    <path name="low-latency-playback display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia5" value="1" />
+    </path>
+
     <path name="low-latency-playback bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia5" value="1" />
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia5" value="1" />
     </path>
 
     <path name="low-latency-playback bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="low-latency-playback bt-sco" />
     </path>
 
@@ -692,12 +801,21 @@
         <path name="low-latency-playback" />
     </path>
 
+    <path name="low-latency-playback speaker-and-display-port">
+        <path name="low-latency-playback display-port" />
+        <path name="low-latency-playback" />
+    </path>
+
     <path name="low-latency-playback afe-proxy">
         <ctl name="AFE_PCM_RX Audio Mixer MultiMedia5" value="1" />
     </path>
 
     <path name="low-latency-playback usb-headphones">
-        <path name="low-latency-playback afe-proxy" />
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia5" value="1" />
     </path>
 
     <path name="low-latency-playback speaker-and-usb-headphones">
@@ -706,445 +824,12 @@
     </path>
 
     <path name="low-latency-playback headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="low-latency-playback speaker-and-headphones">
+        <path name="low-latency-playback headphones" />
         <path name="low-latency-playback" />
-    </path>
-
-    <path name="audio-ull-playback">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia3" value="1" />
-    </path>
-
-    <path name="audio-ull-playback headphones">
-      <path name="audio-ull-playback" />
-    </path>
-
-    <path name="audio-ull-playback speaker-and-headphones">
-        <path name="audio-ull-playback" />
-        <path name="audio-ull-playback headphones" />
-    </path>
-
-    <path name="audio-ull-playback hdmi">
-        <ctl name="HDMI Mixer MultiMedia3" value="1" />
-    </path>
-
-    <path name="audio-ull-playback bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia3" value="1" />
-    </path>
-
-    <path name="audio-ull-playback bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <path name="audio-ull-playback bt-sco" />
-    </path>
-
-    <path name="audio-ull-playback speaker-and-hdmi">
-        <path name="audio-ull-playback hdmi" />
-        <path name="audio-ull-playback" />
-    </path>
-
-    <path name="audio-ull-playback afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia3" value="1" />
-    </path>
-    <path name="multi-channel-playback hdmi">
-        <ctl name="HDMI Mixer MultiMedia2" value="1" />
-    </path>
-
-    <path name="multi-channel-playback afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia2" value="1" />
-    </path>
-
-    <path name="compress-offload-playback">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia4" value="1" />
-    </path>
-
-    <path name="compress-offload-playback hdmi">
-        <ctl name="HDMI Mixer MultiMedia4" value="1" />
-    </path>
-
-    <path name="compress-offload-playback bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia4" value="1" />
-    </path>
-
-    <path name="compress-offload-playback bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback speaker-and-hdmi">
-        <path name="compress-offload-playback hdmi" />
-        <path name="compress-offload-playback" />
-    </path>
-
-    <path name="compress-offload-playback afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia4" value="1" />
-    </path>
-
-    <path name="compress-offload-playback usb-headphones">
-        <path name="compress-offload-playback afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback speaker-and-usb-headphones">
-        <path name="compress-offload-playback usb-headphones" />
-        <path name="compress-offload-playback" />
-    </path>
-
-    <path name="compress-offload-playback headphones">
-        <path name="compress-offload-playback" />
-    </path>
-
-    <path name="compress-offload-playback headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia4" value="1" />
-    </path>
-
-    <path name="compress-offload-playback2">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia7" value="1" />
-    </path>
-
-    <path name="compress-offload-playback2 hdmi">
-        <ctl name="HDMI Mixer MultiMedia7" value="1" />
-    </path>
-
-    <path name="compress-offload-playback2 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia7" value="1" />
-    </path>
-
-    <path name="compress-offload-playback2 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback2 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback2 speaker-and-hdmi">
-        <path name="compress-offload-playback2 hdmi" />
-        <path name="compress-offload-playback2" />
-    </path>
-
-    <path name="compress-offload-playback2 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia7" value="1" />
-    </path>
-
-    <path name="compress-offload-playback2 usb-headphones">
-        <path name="compress-offload-playback2 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback2 speaker-and-usb-headphones">
-        <path name="compress-offload-playback2 usb-headphones" />
-        <path name="compress-offload-playback2" />
-    </path>
-
-    <path name="compress-offload-playback2 headphones">
-        <path name="compress-offload-playback2" />
-    </path>
-
-    <path name="compress-offload-playback2 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia7" value="1" />
-    </path>
-
-    <path name="compress-offload-playback3">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia10" value="1" />
-    </path>
-
-    <path name="compress-offload-playback3 hdmi">
-        <ctl name="HDMI Mixer MultiMedia10" value="1" />
-    </path>
-
-    <path name="compress-offload-playback3 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia10" value="1" />
-    </path>
-
-    <path name="compress-offload-playback3 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback3 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback3 speaker-and-hdmi">
-        <path name="compress-offload-playback3 hdmi" />
-        <path name="compress-offload-playback3" />
-    </path>
-
-    <path name="compress-offload-playback3 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia10" value="1" />
-    </path>
-
-    <path name="compress-offload-playback3 usb-headphones">
-        <path name="compress-offload-playback3 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback3 speaker-and-usb-headphones">
-        <path name="compress-offload-playback3 usb-headphones" />
-        <path name="compress-offload-playback3" />
-    </path>
-
-    <path name="compress-offload-playback3 headphones">
-        <path name="compress-offload-playback3" />
-    </path>
-
-    <path name="compress-offload-playback3 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia10" value="1" />
-    </path>
-
-    <path name="compress-offload-playback4">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia11" value="1" />
-    </path>
-
-    <path name="compress-offload-playback4 hdmi">
-        <ctl name="HDMI Mixer MultiMedia11" value="1" />
-    </path>
-
-    <path name="compress-offload-playback4 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia11" value="1" />
-    </path>
-
-    <path name="compress-offload-playback4 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback4 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback4 speaker-and-hdmi">
-        <path name="compress-offload-playback4 hdmi" />
-        <path name="compress-offload-playback4" />
-    </path>
-
-    <path name="compress-offload-playback4 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia11" value="1" />
-    </path>
-
-    <path name="compress-offload-playback4 usb-headphones">
-        <path name="compress-offload-playback4 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback4 speaker-and-usb-headphones">
-        <path name="compress-offload-playback4 usb-headphones" />
-        <path name="compress-offload-playback4" />
-    </path>
-
-    <path name="compress-offload-playback4 headphones">
-        <path name="compress-offload-playback4" />
-    </path>
-
-    <path name="compress-offload-playback4 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia11" value="1" />
-    </path>
-
-    <path name="compress-offload-playback5">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia12" value="1" />
-    </path>
-
-    <path name="compress-offload-playback5 hdmi">
-        <ctl name="HDMI Mixer MultiMedia12" value="1" />
-    </path>
-
-    <path name="compress-offload-playback5 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia12" value="1" />
-    </path>
-
-    <path name="compress-offload-playback5 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback5 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback5 speaker-and-hdmi">
-        <path name="compress-offload-playback5 hdmi" />
-        <path name="compress-offload-playback5" />
-    </path>
-
-    <path name="compress-offload-playback5 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia12" value="1" />
-    </path>
-
-    <path name="compress-offload-playback5 usb-headphones">
-        <path name="compress-offload-playback5 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback5 speaker-and-usb-headphones">
-        <path name="compress-offload-playback5 usb-headphones" />
-        <path name="compress-offload-playback5" />
-    </path>
-
-    <path name="compress-offload-playback5 headphones">
-        <path name="compress-offload-playback5" />
-    </path>
-
-    <path name="compress-offload-playback5 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia12" value="1" />
-    </path>
-
-    <path name="compress-offload-playback6">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia13" value="1" />
-    </path>
-
-    <path name="compress-offload-playback6 hdmi">
-        <ctl name="HDMI Mixer MultiMedia13" value="1" />
-    </path>
-
-    <path name="compress-offload-playback6 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia13" value="1" />
-    </path>
-
-    <path name="compress-offload-playback6 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback6 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback6 speaker-and-hdmi">
-        <path name="compress-offload-playback6 hdmi" />
-        <path name="compress-offload-playback6" />
-    </path>
-
-    <path name="compress-offload-playback6 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia13" value="1" />
-    </path>
-
-    <path name="compress-offload-playback6 usb-headphones">
-        <path name="compress-offload-playback6 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback6 speaker-and-usb-headphones">
-        <path name="compress-offload-playback6 usb-headphones" />
-        <path name="compress-offload-playback6" />
-    </path>
-
-    <path name="compress-offload-playback6 headphones">
-        <path name="compress-offload-playback6" />
-    </path>
-
-    <path name="compress-offload-playback6 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia13" value="1" />
-    </path>
-
-    <path name="compress-offload-playback7">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia14" value="1" />
-    </path>
-
-    <path name="compress-offload-playback7 hdmi">
-        <ctl name="HDMI Mixer MultiMedia14" value="1" />
-    </path>
-
-    <path name="compress-offload-playback7 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia14" value="1" />
-    </path>
-
-    <path name="compress-offload-playback7 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback7 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback7 speaker-and-hdmi">
-        <path name="compress-offload-playback7 hdmi" />
-        <path name="compress-offload-playback7" />
-    </path>
-
-    <path name="compress-offload-playback7 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia14" value="1" />
-    </path>
-
-    <path name="compress-offload-playback7 usb-headphones">
-        <path name="compress-offload-playback7 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback7 speaker-and-usb-headphones">
-        <path name="compress-offload-playback7 usb-headphones" />
-        <path name="compress-offload-playback7" />
-    </path>
-
-    <path name="compress-offload-playback7 headphones">
-        <path name="compress-offload-playback7" />
-    </path>
-
-    <path name="compress-offload-playback7 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia14" value="1" />
-    </path>
-
-    <path name="compress-offload-playback8">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia15" value="1" />
-    </path>
-
-    <path name="compress-offload-playback8 hdmi">
-        <ctl name="HDMI Mixer MultiMedia15" value="1" />
-    </path>
-
-    <path name="compress-offload-playback8 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia15" value="1" />
-    </path>
-
-    <path name="compress-offload-playback8 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback8 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback8 speaker-and-hdmi">
-        <path name="compress-offload-playback8 hdmi" />
-        <path name="compress-offload-playback8" />
-    </path>
-
-    <path name="compress-offload-playback8 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia15" value="1" />
-    </path>
-
-    <path name="compress-offload-playback8 usb-headphones">
-        <path name="compress-offload-playback8 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback8 speaker-and-usb-headphones">
-        <path name="compress-offload-playback8 usb-headphones" />
-        <path name="compress-offload-playback8" />
-    </path>
-
-    <path name="compress-offload-playback8 headphones">
-        <path name="compress-offload-playback8" />
-    </path>
-
-    <path name="compress-offload-playback8 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia15" value="1" />
-    </path>
-
-    <path name="compress-offload-playback9">
-        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia16" value="1" />
-    </path>
-
-    <path name="compress-offload-playback9 hdmi">
-        <ctl name="HDMI Mixer MultiMedia16" value="1" />
-    </path>
-
-    <path name="compress-offload-playback9 bt-sco">
-        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia16" value="1" />
-    </path>
-
-    <path name="compress-offload-playback9 bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
-        <path name="compress-offload-playback9 bt-sco" />
-    </path>
-
-    <path name="compress-offload-playback9 speaker-and-hdmi">
-        <path name="compress-offload-playback9 hdmi" />
-        <path name="compress-offload-playback9" />
-    </path>
-
-    <path name="compress-offload-playback9 afe-proxy">
-        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia16" value="1" />
-    </path>
-
-    <path name="compress-offload-playback9 usb-headphones">
-        <path name="compress-offload-playback9 afe-proxy" />
-    </path>
-
-    <path name="compress-offload-playback9 speaker-and-usb-headphones">
-        <path name="compress-offload-playback9 usb-headphones" />
-        <path name="compress-offload-playback9" />
-    </path>
-
-    <path name="compress-offload-playback9 headphones">
-        <path name="compress-offload-playback9" />
-    </path>
-
-    <path name="compress-offload-playback9 headphones-44.1">
-        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia16" value="1" />
     </path>
 
     <path name="low-latency-playback incall-music">
@@ -1156,7 +841,15 @@
     </path>
 
     <path name="low-latency-playback incall-music-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="low-latency-playback incall-music" />
+    </path>
+
+    <path name="low-latency-playback incall-music-usb-headphones">
+        <path name="low-latency-playback incall-music" />
+    </path>
+
+    <path name="low-latency-playback incall-music-usb-headset">
         <path name="low-latency-playback incall-music" />
     </path>
 
@@ -1169,8 +862,646 @@
     </path>
 
     <path name="low-latency-playback incall-music2-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="low-latency-playback incall-music2" />
+    </path>
+
+    <path name="low-latency-playback incall-music2-usb-headphones">
+        <path name="low-latency-playback incall-music2" />
+    </path>
+
+    <path name="low-latency-playback incall-music2-usb-headset">
+        <path name="low-latency-playback incall-music2" />
+    </path>
+
+    <path name="audio-ull-playback">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia8" value="1" />
+    </path>
+
+    <path name="audio-ull-playback speaker-protected">
+        <path name="audio-ull-playback" />
+    </path>
+
+    <path name="audio-ull-playback headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia8" value="1" />
+    </path>
+
+    <path name="audio-ull-playback speaker-and-headphones">
+        <path name="audio-ull-playback" />
+        <path name="audio-ull-playback headphones" />
+    </path>
+
+    <path name="audio-ull-playback hdmi">
+        <ctl name="HDMI Mixer MultiMedia8" value="1" />
+    </path>
+
+    <path name="audio-ull-playback display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia3" value="1" />
+    </path>
+
+    <path name="audio-ull-playback bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia8" value="1" />
+    </path>
+
+    <path name="audio-ull-playback bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="audio-ull-playback bt-sco" />
+    </path>
+
+    <path name="audio-ull-playback speaker-and-hdmi">
+        <path name="audio-ull-playback hdmi" />
+        <path name="audio-ull-playback" />
+    </path>
+
+    <path name="audio-ull-playback speaker-and-display-port">
+        <path name="audio-ull-playback display-port" />
+        <path name="audio-ull-playback" />
+    </path>
+
+    <path name="audio-ull-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia8" value="1" />
+    </path>
+
+    <path name="audio-ull-playback usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia8" value="1" />
+    </path>
+
+    <path name="audio-ull-playback usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia8" value="1" />
+    </path>
+
+    <path name="multi-channel-playback hdmi">
+        <ctl name="HDMI Mixer MultiMedia2" value="1" />
+    </path>
+
+    <path name="multi-channel-playback display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia2" value="1" />
+    </path>
+
+    <path name="multi-channel-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia2" value="1" />
+    </path>
+
+    <path name="compress-offload-playback">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback speaker-protected">
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback hdmi">
+        <ctl name="HDMI Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="silence-playback hdmi">
+        <ctl name="HDMI Mixer MultiMedia9" value="1" />
+    </path>
+
+    <path name="compress-offload-playback display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="silence-playback display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia9" value="1" />
+    </path>
+
+    <path name="compress-offload-playback bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback speaker-and-hdmi">
+        <path name="compress-offload-playback hdmi" />
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback speaker-and-display-port">
+        <path name="compress-offload-playback display-port" />
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback speaker-and-usb-headphones">
+        <path name="compress-offload-playback usb-headphones" />
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback speaker-and-headphones">
+        <path name="compress-offload-playback headphones" />
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="compress-offload-playback2">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 hdmi">
+        <ctl name="HDMI Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback2 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback2 speaker-and-hdmi">
+        <path name="compress-offload-playback2 hdmi" />
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback2 speaker-and-display-port">
+        <path name="compress-offload-playback2 display-port" />
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback2 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 speaker-and-usb-headphones">
+        <path name="compress-offload-playback2 usb-headphones" />
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback2 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 speaker-and-headphones">
+        <path name="compress-offload-playback2 headphones" />
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback3">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 hdmi">
+        <ctl name="HDMI Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback3 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback3 speaker-and-hdmi">
+        <path name="compress-offload-playback3 hdmi" />
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback3 speaker-and-display-port">
+        <path name="compress-offload-playback3 display-port" />
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback3 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 speaker-and-usb-headphones">
+        <path name="compress-offload-playback3 usb-headphones" />
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback3 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 speaker-and-headphones">
+        <path name="compress-offload-playback3 headphones" />
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback4">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 hdmi">
+        <ctl name="HDMI Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback4 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback4 speaker-and-hdmi">
+        <path name="compress-offload-playback4 hdmi" />
+        <path name="compress-offload-playback4" />
+    </path>
+
+    <path name="compress-offload-playback4 speaker-and-display-port">
+        <path name="compress-offload-playback4 display-port" />
+        <path name="compress-offload-playback4" />
+    </path>
+
+
+    <path name="compress-offload-playback4 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 speaker-and-usb-headphones">
+        <path name="compress-offload-playback4 usb-headphones" />
+        <path name="compress-offload-playback4" />
+    </path>
+
+    <path name="compress-offload-playback4 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 speaker-and-headphones">
+        <path name="compress-offload-playback4 headphones" />
+        <path name="compress-offload-playback4" />
+    </path>
+
+    <path name="compress-offload-playback5">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 hdmi">
+        <ctl name="HDMI Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback5 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback5 speaker-and-hdmi">
+        <path name="compress-offload-playback5 hdmi" />
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback5 speaker-and-display-port">
+        <path name="compress-offload-playback5 display-port" />
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback5 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 speaker-and-usb-headphones">
+        <path name="compress-offload-playback5 usb-headphones" />
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback5 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 speaker-and-headphones">
+        <path name="compress-offload-playback5 headphones" />
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback6">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 hdmi">
+        <ctl name="HDMI Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback6 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback6 speaker-and-hdmi">
+        <path name="compress-offload-playback6 hdmi" />
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback6 speaker-and-display-port">
+        <path name="compress-offload-playback6 display-port" />
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback6 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 speaker-and-usb-headphones">
+        <path name="compress-offload-playback6 usb-headphones" />
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback6 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 speaker-and-headphones">
+        <path name="compress-offload-playback6 headphones" />
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback7">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 hdmi">
+        <ctl name="HDMI Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback7 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback7 speaker-and-hdmi">
+        <path name="compress-offload-playback7 hdmi" />
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback7 speaker-and-display-port">
+        <path name="compress-offload-playback7 display-port" />
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback7 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 speaker-and-usb-headphones">
+        <path name="compress-offload-playback7 usb-headphones" />
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback7 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 speaker-and-headphones">
+        <path name="compress-offload-playback7 headphones" />
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback8">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 hdmi">
+        <ctl name="HDMI Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback8 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback8 speaker-and-hdmi">
+        <path name="compress-offload-playback8 hdmi" />
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback8 speaker-and-display-port">
+        <path name="compress-offload-playback8 display-port" />
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback8 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 speaker-and-usb-headphones">
+        <path name="compress-offload-playback8 usb-headphones" />
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback8 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 speaker-and-headphones">
+        <path name="compress-offload-playback8 headphones" />
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback9">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 hdmi">
+        <ctl name="HDMI Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 display-port">
+        <ctl name="DISPLAY_PORT Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 bt-sco">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 bt-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="compress-offload-playback9 bt-sco" />
+    </path>
+
+    <path name="compress-offload-playback9 speaker-and-hdmi">
+        <path name="compress-offload-playback9 hdmi" />
+        <path name="compress-offload-playback9" />
+    </path>
+
+    <path name="compress-offload-playback9 speaker-and-display-port">
+        <path name="compress-offload-playback9 display-port" />
+        <path name="compress-offload-playback9" />
+    </path>
+
+    <path name="compress-offload-playback9 afe-proxy">
+        <ctl name="AFE_PCM_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 usb-headphones">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 usb-headset">
+        <ctl name="USB_AUDIO_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 speaker-and-usb-headphones">
+        <path name="compress-offload-playback9 usb-headphones" />
+        <path name="compress-offload-playback9" />
+    </path>
+
+    <path name="compress-offload-playback9 headphones">
+        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 headphones-44.1">
+        <ctl name="SLIMBUS_5_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 speaker-and-headphones">
+        <path name="compress-offload-playback9 headphones" />
+        <path name="compress-offload-playback9" />
     </path>
 
     <path name="audio-record">
@@ -1178,21 +1509,20 @@
     </path>
 
     <path name="audio-record usb-headset-mic">
-        <ctl name="MultiMedia1 Mixer AFE_PCM_TX" value="1" />
+        <ctl name="MultiMedia1 Mixer USB_AUDIO_TX" value="1" />
     </path>
 
     <path name="audio-record bt-sco">
-        <ctl name="MultiMedia1 Mixer AUX_PCM_UL_TX" value="1" />
+        <ctl name="MultiMedia1 Mixer SLIM_7_TX" value="1" />
     </path>
 
     <path name="audio-record bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="audio-record bt-sco" />
     </path>
 
     <path name="audio-record capture-fm">
-        <ctl name="MultiMedia1 Mixer TERT_MI2S_TX" value="1" />
+        <ctl name="MultiMedia1 Mixer SLIM_8_TX" value="1" />
     </path>
 
     <path name="audio-record capture-ahc">
@@ -1204,148 +1534,53 @@
     </path>
 
     <path name="audio-record-compress bt-sco">
-        <ctl name="MultiMedia8 Mixer AUX_PCM_UL_TX" value="1" />
+        <ctl name="MultiMedia8 Mixer SLIM_7_TX" value="1" />
     </path>
 
     <path name="audio-record-compress bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="audio-record-compress bt-sco" />
     </path>
 
     <path name="audio-record-compress usb-headset-mic">
-        <ctl name="MultiMedia8 Mixer AFE_PCM_TX" value="1" />
+        <ctl name="MultiMedia8 Mixer USB_AUDIO_TX" value="1" />
     </path>
 
     <path name="low-latency-record">
-      <ctl name="MultiMedia5 Mixer SLIM_0_TX" value="1" />
+      <ctl name="MultiMedia8 Mixer SLIM_0_TX" value="1" />
     </path>
 
     <path name="low-latency-record bt-sco">
-      <ctl name="MultiMedia5 Mixer AUX_PCM_UL_TX" value="1" />
+      <ctl name="MultiMedia8 Mixer SLIM_7_TX" value="1" />
     </path>
 
     <path name="low-latency-record bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="low-latency-record bt-sco" />
     </path>
 
     <path name="low-latency-record usb-headset-mic">
-        <ctl name="MultiMedia5 Mixer AFE_PCM_TX" value="1" />
+        <ctl name="MultiMedia8 Mixer USB_AUDIO_TX" value="1" />
     </path>
 
     <path name="low-latency-record capture-fm">
-      <ctl name="MultiMedia5 Mixer TERT_MI2S_TX" value="1" />
+      <ctl name="MultiMedia8 Mixer SLIM_8_TX" value="1" />
     </path>
 
     <path name="fm-virtual-record capture-fm">
-        <ctl name="MultiMedia2 Mixer TERT_MI2S_TX" value="1" />
-    </path>
-
-    <path name="voice-call">
-        <ctl name="SLIM_0_RX_Voice Mixer CSVoice" value="1" />
-        <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="1" />
-    </path>
-
-    <path name="voice-call hdmi">
-        <ctl name="HDMI_RX_Voice Mixer CSVoice" value="1" />
-        <ctl name="Voice_Tx Mixer SLIM_0_TX_Voice" value="1" />
-    </path>
-
-    <path name="voice-call bt-sco">
-        <ctl name="AUX_PCM_RX_Voice Mixer CSVoice" value="1" />
-        <ctl name="Voice_Tx Mixer AUX_PCM_TX_Voice" value="1" />
-    </path>
-
-    <path name="voice-call bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <path name="voice-call bt-sco" />
-    </path>
-
-    <path name="voice-call afe-proxy">
-        <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="1" />
-        <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="1" />
-    </path>
-
-    <path name="voice-call usb-headphones">
-        <ctl name="AFE_PCM_RX_Voice Mixer CSVoice" value="1" />
-        <ctl name="Voice_Tx Mixer AFE_PCM_TX_Voice" value="1" />
-    </path>
-
-    <path name="voice-call incall-music">
-        <path name="voice-call" />
-    </path>
-
-    <path name="voice-call incall-music-bt">
-        <path name="voice-call bt-sco" />
-    </path>
-
-    <path name="voice-call incall-music-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <path name="voice-call incall-music-bt" />
-    </path>
-
-    <path name="voice2-call">
-        <ctl name="SLIM_0_RX_Voice Mixer Voice2" value="1" />
-        <ctl name="Voice2_Tx Mixer SLIM_0_TX_Voice2" value="1" />
-    </path>
-
-    <path name="voice-call voice-speaker-vbat">
-        <path name="echo-reference speaker-vbat-mono" />
-        <path name="voice-call"/>
-    </path>
-
-    <path name="voice2-call hdmi">
-        <ctl name="HDMI_RX_Voice Mixer Voice2" value="1" />
-        <ctl name="Voice2_Tx Mixer SLIM_0_TX_Voice2" value="1" />
-    </path>
-
-    <path name="voice2-call bt-sco">
-        <ctl name="AUX_PCM_RX_Voice Mixer Voice2" value="1" />
-        <ctl name="Voice2_Tx Mixer AUX_PCM_TX_Voice2" value="1" />
-    </path>
-
-    <path name="voice2-call bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <path name="voice2-call bt-sco" />
-    </path>
-
-    <path name="voice2-call afe-proxy">
-        <ctl name="AFE_PCM_RX_Voice Mixer Voice2" value="1" />
-        <ctl name="Voice2_Tx Mixer AFE_PCM_TX_Voice2" value="1" />
-    </path>
-
-    <path name="voice2-call usb-headphones">
-        <ctl name="AFE_PCM_RX_Voice Mixer Voice2" value="1" />
-        <ctl name="Voice2_Tx Mixer AFE_PCM_TX_Voice2" value="1" />
-    </path>
-
-    <path name="voice2-call voice-speaker-vbat">
-        <path name="echo-reference speaker-vbat-mono" />
-        <path name="voice2-call"/>
-    </path>
-
-    <path name="voice2-call incall-music2">
-        <path name="voice2-call" />
-    </path>
-
-    <path name="voice2-call incall-music2-bt">
-        <path name="voice2-call bt-sco" />
-    </path>
-
-    <path name="voice2-call incall-music2-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <path name="voice2-call incall-music2-bt" />
+        <ctl name="MultiMedia2 Mixer SLIM_8_TX" value="1" />
     </path>
 
     <path name="play-fm">
-        <ctl name="Tert MI2S LOOPBACK Volume" value="1" />
-        <ctl name="SLIMBUS_0_RX Port Mixer TERT_MI2S_TX" value="1" />
+        <ctl name="SLIMBUS_8 LOOPBACK Volume" value="1" />
+        <ctl name="SLIMBUS_0_RX Port Mixer SLIM_8_TX" value="1" />
         <ctl name="SLIMBUS_DL_HL Switch" value="1" />
     </path>
 
     <path name="play-fm headphones">
-        <path name="play-fm" />
+        <ctl name="SLIMBUS_8 LOOPBACK Volume" value="1" />
+        <ctl name="SLIMBUS_6_RX Port Mixer SLIM_8_TX" value="1" />
+        <ctl name="SLIMBUS6_DL_HL Switch" value="1" />
     </path>
 
     <path name="incall-rec-uplink">
@@ -1470,113 +1705,30 @@
         <path name="incall-rec-uplink-and-downlink-compress" />
     </path>
 
-    <path name="incall_music_uplink">
-        <ctl name="Incall_Music Audio Mixer MultiMedia2" value="1" />
-    </path>
-
-    <path name="incall_music_uplink bt-sco">
-        <path name="incall_music_uplink" />
-    </path>
-
-    <path name="incall_music_uplink bt-sco-wb">
-        <path name="incall_music_uplink" />
-    </path>
-
-    <path name="incall_music_uplink afe-proxy">
-        <path name="incall_music_uplink" />
-    </path>
-
-    <path name="incall_music_uplink usb-headphones">
-        <path name="incall_music_uplink" />
-    </path>
-
-    <path name="incall_music_uplink hdmi">
-        <path name="incall_music_uplink" />
-    </path>
-
-    <path name="incall_music_uplink2">
-        <ctl name="Incall_Music_2 Audio Mixer MultiMedia9" value="1" />
-    </path>
-
-    <path name="incall_music_uplink2 bt-sco">
-        <path name="incall_music_uplink2" />
-    </path>
-
-    <path name="incall_music_uplink2 bt-sco-wb">
-        <path name="incall_music_uplink2" />
-    </path>
-
-    <path name="incall_music_uplink2 afe-proxy">
-        <path name="incall_music_uplink2" />
-    </path>
-
-    <path name="incall_music_uplink2 usb-headphones">
-        <path name="incall_music_uplink2" />
-    </path>
-
-    <path name="incall_music_uplink2 hdmi">
-        <path name="incall_music_uplink2" />
-    </path>
-
     <path name="hfp-sco">
-        <ctl name="HFP_AUX_UL_HL Switch" value="1" />
-        <ctl name="SLIMBUS_0_RX Port Mixer AUX_PCM_TX" value="1" />
-        <ctl name="AUX_PCM_RX  Audio Mixer MultiMedia6" value="1" />
+        <ctl name="HFP_PRI_AUX_UL_HL Switch" value="1" />
+        <ctl name="SLIMBUS_0_RX Port Mixer SLIM_7_TX" value="1" />
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia6" value="1" />
         <ctl name="MultiMedia6 Mixer SLIM_0_TX" value="1" />
         <ctl name="SLIMBUS_DL_HL Switch" value="1" />
    </path>
 
+    <path name="hfp-sco headphones">
+        <ctl name="HFP_PRI_AUX_UL_HL Switch" value="1" />
+        <ctl name="SLIMBUS_6_RX Port Mixer AUX_PCM_UL_TX" value="1" />
+        <ctl name="AUX_PCM_RX Audio Mixer MultiMedia6" value="1" />
+        <ctl name="MultiMedia6 Mixer SLIM_0_TX" value="1" />
+        <ctl name="SLIMBUS6_DL_HL Switch" value="1" />
+    </path>
+
    <path name="hfp-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="hfp-sco" />
    </path>
 
-    <path name="volte-call">
-        <ctl name="SLIM_0_RX_Voice Mixer VoLTE" value="1" />
-        <ctl name="VoLTE_Tx Mixer SLIM_0_TX_VoLTE" value="1" />
-    </path>
-
-    <path name="volte-call hdmi">
-        <ctl name="HDMI_RX_Voice Mixer VoLTE" value="1" />
-        <ctl name="VoLTE_Tx Mixer SLIM_0_TX_VoLTE" value="1" />
-    </path>
-
-    <path name="volte-call bt-sco">
-        <ctl name="AUX_PCM_RX_Voice Mixer VoLTE" value="1" />
-        <ctl name="VoLTE_Tx Mixer AUX_PCM_TX_VoLTE" value="1" />
-    </path>
-
-    <path name="volte-call bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <path name="volte-call bt-sco" />
-    </path>
-
-    <path name="volte-call afe-proxy">
-        <ctl name="AFE_PCM_RX_Voice Mixer VoLTE" value="1" />
-        <ctl name="VoLTE_Tx Mixer AFE_PCM_TX_VoLTE" value="1" />
-    </path>
-
-    <path name="volte-call incall-music">
-        <path name="volte-call" />
-    </path>
-
-    <path name="volte-call incall-music-bt">
-        <path name="volte-call bt-sco" />
-    </path>
-
-    <path name="volte-call incall-music-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <path name="volte-call incall-music-bt" />
-    </path>
-
-    <path name="volte-call usb-headphones">
-        <ctl name="AFE_PCM_RX_Voice Mixer VoLTE" value="1" />
-        <ctl name="VoLTE_Tx Mixer AFE_PCM_TX_VoLTE" value="1" />
-    </path>
-
-    <path name="volte-call voice-speaker-vbat">
-        <path name="echo-reference speaker-vbat-mono" />
-        <path name="volte-call"/>
+    <path name="hfp-sco-wb headphones">
+        <ctl name="AUX PCM SampleRate" value="KHZ_16" />
+        <path name="hfp-sco headphones" />
     </path>
 
     <path name="compress-voip-call">
@@ -1584,14 +1736,19 @@
         <ctl name="Voip_Tx Mixer SLIM_0_TX_Voip" value="1" />
     </path>
 
+    <path name="compress-voip-call headphones">
+        <ctl name="SLIM_6_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer SLIM_0_TX_Voip" value="1" />
+    </path>
+
+
     <path name="compress-voip-call bt-sco">
-        <ctl name="AUX_PCM_RX_Voice Mixer Voip" value="1" />
-        <ctl name="Voip_Tx Mixer AUX_PCM_TX_Voip" value="1" />
+        <ctl name="SLIM_7_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer SLIM_7_TX_Voip" value="1" />
     </path>
 
     <path name="compress-voip-call bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
-        <ctl name="SLIM_1 SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="compress-voip-call bt-sco" />
     </path>
 
@@ -1601,17 +1758,32 @@
     </path>
 
     <path name="compress-voip-call usb-headphones">
-        <ctl name="AFE_PCM_RX_Voice Mixer Voip" value="1" />
-        <ctl name="Voip_Tx Mixer AFE_PCM_TX_Voip" value="1" />
+        <ctl name="USB_AUDIO_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer SLIM_0_TX_Voip" value="1" />
     </path>
+
+    <path name="compress-voip-call usb-headset">
+        <ctl name="USB_AUDIO_RX_Voice Mixer Voip" value="1" />
+        <ctl name="Voip_Tx Mixer USB_AUDIO_TX_Voip" value="1" />
+     </path>
 
     <path name="compress-voip-call voice-speaker-vbat">
         <path name="echo-reference speaker-vbat-mono" />
         <path name="compress-voip-call"/>
     </path>
 
+    <path name="compress-voip-call voice-speaker-2-vbat">
+        <path name="echo-reference speaker-vbat-mono-2" />
+        <path name="compress-voip-call"/>
+    </path>
+
     <path name="vowlan-call">
         <ctl name="SLIM_0_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer SLIM_0_TX_VoWLAN" value="1" />
+    </path>
+
+    <path name="vowlan-call headphones">
+        <ctl name="SLIM_6_RX_Voice Mixer VoWLAN" value="1" />
         <ctl name="VoWLAN_Tx Mixer SLIM_0_TX_VoWLAN" value="1" />
     </path>
 
@@ -1621,12 +1793,12 @@
     </path>
 
     <path name="vowlan-call bt-sco">
-        <ctl name="AUX_PCM_RX_Voice Mixer VoWLAN" value="1" />
-        <ctl name="VoWLAN_Tx Mixer AUX_PCM_TX_VoWLAN" value="1" />
+        <ctl name="SLIM_7_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer SLIM_7_TX_VoWLAN" value="1" />
     </path>
 
     <path name="vowlan-call bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="vowlan-call bt-sco" />
     </path>
 
@@ -1636,8 +1808,13 @@
     </path>
 
     <path name="vowlan-call usb-headphones">
-        <ctl name="AFE_PCM_RX_Voice Mixer VoWLAN" value="1" />
-        <ctl name="VoWLAN_Tx Mixer AFE_PCM_TX_VoWLAN" value="1" />
+        <ctl name="USB_AUDIO_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer SLIM_0_TX_VoWLAN" value="1" />
+    </path>
+
+    <path name="vowlan-call usb-headset">
+        <ctl name="USB_AUDIO_RX_Voice Mixer VoWLAN" value="1" />
+        <ctl name="VoWLAN_Tx Mixer USB_AUDIO_TX_VoWLAN" value="1" />
     </path>
 
     <path name="vowlan-call voice-speaker-vbat">
@@ -1645,8 +1822,18 @@
         <path name="vowlan-call"/>
     </path>
 
+    <path name="vowlan-call voice-speaker-2-vbat">
+        <path name="echo-reference speaker-vbat-mono-2" />
+        <path name="vowlan-call"/>
+    </path>
+
     <path name="voicemmode1-call">
         <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="1" />
+    </path>
+
+    <path name="voicemmode1-call headphones">
+        <ctl name="SLIM_6_RX_Voice Mixer VoiceMMode1" value="1" />
         <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="1" />
     </path>
 
@@ -1656,12 +1843,12 @@
     </path>
 
     <path name="voicemmode1-call bt-sco">
-        <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode1" value="1" />
-        <ctl name="VoiceMMode1_Tx Mixer AUX_PCM_TX_MMode1" value="1" />
+        <ctl name="SLIM_7_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer SLIM_7_TX_MMode1" value="1" />
     </path>
 
     <path name="voicemmode1-call bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="voicemmode1-call bt-sco" />
     </path>
 
@@ -1671,12 +1858,22 @@
     </path>
 
     <path name="voicemmode1-call usb-headphones">
-        <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode1" value="1" />
-        <ctl name="VoiceMMode1_Tx Mixer AFE_PCM_TX_MMode1" value="1" />
+        <ctl name="USB_AUDIO_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer SLIM_0_TX_MMode1" value="1" />
+    </path>
+
+    <path name="voicemmode1-call usb-headset">
+        <ctl name="USB_AUDIO_RX_Voice Mixer VoiceMMode1" value="1" />
+        <ctl name="VoiceMMode1_Tx Mixer USB_AUDIO_TX_MMode1" value="1" />
     </path>
 
     <path name="voicemmode1-call voice-speaker-vbat">
         <path name="echo-reference speaker-vbat-mono" />
+        <path name="voicemmode1-call"/>
+    </path>
+
+    <path name="voicemmode1-call voice-speaker-2-vbat">
+        <path name="echo-reference speaker-vbat-mono-2" />
         <path name="voicemmode1-call"/>
     </path>
 
@@ -1689,16 +1886,25 @@
     </path>
 
     <path name="voicemmode1-call incall-music-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="voicemmode1-call incall-music-bt" />
     </path>
 
-    <path name="voicemmode1-call headphones">
-        <path name="voicemmode1-call"/>
+    <path name="voicemmode1-call incall-music-usb-headphones">
+        <path name="voicemmode1-call usb-headphones" />
+    </path>
+
+    <path name="voicemmode1-call incall-music-usb-headset">
+        <path name="voicemmode1-call usb-headset" />
     </path>
 
     <path name="voicemmode2-call">
         <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="1" />
+    </path>
+
+    <path name="voicemmode2-call headphones">
+        <ctl name="SLIM_6_RX_Voice Mixer VoiceMMode2" value="1" />
         <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="1" />
     </path>
 
@@ -1708,12 +1914,12 @@
     </path>
 
     <path name="voicemmode2-call bt-sco">
-        <ctl name="AUX_PCM_RX_Voice Mixer VoiceMMode2" value="1" />
-        <ctl name="VoiceMMode2_Tx Mixer AUX_PCM_TX_MMode2" value="1" />
+        <ctl name="SLIM_7_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer SLIM_7_TX_MMode2" value="1" />
     </path>
 
     <path name="voicemmode2-call bt-sco-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="voicemmode2-call bt-sco" />
     </path>
 
@@ -1723,12 +1929,22 @@
     </path>
 
     <path name="voicemmode2-call usb-headphones">
-        <ctl name="AFE_PCM_RX_Voice Mixer VoiceMMode2" value="1" />
-        <ctl name="VoiceMMode2_Tx Mixer AFE_PCM_TX_MMode2" value="1" />
+        <ctl name="USB_AUDIO_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="1" />
+    </path>
+
+    <path name="voicemmode2-call usb-headset">
+        <ctl name="USB_AUDIO_RX_Voice Mixer VoiceMMode2" value="1" />
+        <ctl name="VoiceMMode2_Tx Mixer USB_AUDIO_TX_MMode2" value="1" />
     </path>
 
     <path name="voicemmode2-call voice-speaker-vbat">
         <path name="echo-reference speaker-vbat-mono" />
+        <path name="voicemmode2-call"/>
+    </path>
+
+    <path name="voicemmode2-call voice-speaker-2-vbat">
+        <path name="echo-reference speaker-vbat-mono-2" />
         <path name="voicemmode2-call"/>
     </path>
 
@@ -1741,8 +1957,16 @@
     </path>
 
     <path name="voicemmode2-call incall-music2-bt-wb">
-        <ctl name="AUX PCM SampleRate" value="16000" />
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="voicemmode2-call incall-music2-bt" />
+    </path>
+
+    <path name="voicemmode2-call incall-music2-usb-headphones">
+        <path name="voicemmode2-call usb-headphones" />
+    </path>
+
+    <path name="voicemmode2-call incall-music2-usb-headset">
+        <path name="voicemmode2-call usb-headset" />
     </path>
 
     <path name="listen-voice-wakeup-1">
@@ -1833,15 +2057,6 @@
     </path>
 
     <!-- For Tasha, DMIC numbered from 0 to 5 -->
-    <path name="dmic3">
-        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
-        <ctl name="SLIM_0_TX Channels" value="One" />
-        <ctl name="SLIM TX7 MUX" value="DEC7" />
-        <ctl name="ADC MUX7" value="DMIC" />
-        <ctl name="DMIC MUX7" value="DMIC2" />
-        <ctl name="IIR0 INP0 MUX" value="DEC7" />
-    </path>
-
     <path name="dmic1">
         <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
         <ctl name="SLIM_0_TX Channels" value="One" />
@@ -1857,6 +2072,15 @@
         <ctl name="SLIM TX7 MUX" value="DEC7" />
         <ctl name="ADC MUX7" value="DMIC" />
         <ctl name="DMIC MUX7" value="DMIC1" />
+        <ctl name="IIR0 INP0 MUX" value="DEC7" />
+    </path>
+
+    <path name="dmic3">
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="SLIM_0_TX Channels" value="One" />
+        <ctl name="SLIM TX7 MUX" value="DEC7" />
+        <ctl name="ADC MUX7" value="DMIC" />
+        <ctl name="DMIC MUX7" value="DMIC2" />
         <ctl name="IIR0 INP0 MUX" value="DEC7" />
     </path>
 
@@ -1888,6 +2112,8 @@
     </path>
 
     <path name="speaker">
+        <ctl name="COMP7 Switch" value="1" />
+        <ctl name="COMP8 Switch" value="1" />
         <ctl name="AIF4_VI Mixer SPKR_VI_1" value="1" />
         <ctl name="AIF4_VI Mixer SPKR_VI_2" value="1" />
         <ctl name="SLIM_4_TX Format" value="PACKED_16B" />
@@ -1917,6 +2143,7 @@
     </path>
 
     <path name="speaker-fluid">
+        <ctl name="COMP7 Switch" value="1" />
         <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM_0_RX Channels" value="One" />
         <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
@@ -1924,14 +2151,6 @@
         <ctl name="SpkrLeft BOOST Switch" value="1" />
         <ctl name="SpkrLeft VISENSE Switch" value="1" />
         <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
-    </path>
-
-    <path name="fm-speaker">
-        <path name="speaker" />
-    </path>
-
-    <path name="fm-speaker-reverse">
-        <path name="speaker-reverse" />
     </path>
 
     <path name="ringtone-speaker">
@@ -1939,29 +2158,27 @@
         <ctl name="Set Custom Stereo" value="Mix" />
     </path>
 
-    <path name="ringtone-speaker-mono">
-        <path name="speaker" />
-        <ctl name="Set Custom Stereo" value="Mix" />
-    </path>
-
-    <path name="sforce-speaker">
-        <path name="speaker" />
-    </path>
-
-    <path name="sforce-speaker-reverse">
-        <path name="speaker-reverse" />
-    </path>
-
-
     <path name="speaker-mono">
+        <ctl name="COMP7 Switch" value="1" />
         <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM_0_RX Channels" value="One" />
         <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX7 Digital Volume" value="84" />
         <ctl name="SpkrLeft COMP Switch" value="1" />
         <ctl name="SpkrLeft BOOST Switch" value="1" />
         <ctl name="SpkrLeft VISENSE Switch" value="1" />
         <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
+    </path>
+
+    <path name="speaker-mono-2">
+        <ctl name="COMP8 Switch" value="1" />
+        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="One" />
+        <ctl name="RX INT8_1 MIX1 INP0" value="RX1" />
+        <ctl name="RX8 Digital Volume" value="82" />
+        <ctl name="SpkrRight COMP Switch" value="1" />
+        <ctl name="SpkrRight BOOST Switch" value="1" />
+        <ctl name="SpkrRight VISENSE Switch" value="1" />
+        <ctl name="SpkrRight SWR DAC_Port Switch" value="1" />
     </path>
 
     <path name="speaker-liquid">
@@ -1971,6 +2188,11 @@
    <path name="speaker-vbat-mono">
        <path name="speaker-mono" />
        <ctl name="RX INT7 VBAT SPKRL VBAT Enable" value="1" />
+   </path>
+
+   <path name="speaker-vbat-mono-2">
+       <path name="speaker-mono-2" />
+       <ctl name="RX INT8 VBAT SPKRL VBAT Enable" value="1" />
    </path>
 
    <path name="speaker-vbat">
@@ -2177,7 +2399,7 @@
     </path>
 
     <path name="speaker-mic-liquid">
-        <path name="dmic3" />
+        <path name="dmic2" />
         <ctl name="DEC7 Volume" value="111" />
     </path>
 
@@ -2250,19 +2472,33 @@
         <ctl name="DEC7 Volume" value="123" />
     </path>
 
-     <path name="speaker-protected">
+    <path name="speaker-protected">
         <path name="speaker" />
     </path>
 
     <path name="voice-speaker-protected">
         <ctl name="AIF4_VI Mixer SPKR_VI_1" value="1" />
-	<ctl name="SLIM_4_TX Format" value="PACKED_16B" />
+        <ctl name="SLIM_4_TX Format" value="PACKED_16B" />
         <path name="speaker-mono" />
         <ctl name="VI_FEED_TX Channels" value="One" />
         <ctl name="SLIM0_RX_VI_FB_LCH_MUX"  value="SLIM4_TX" />
     </path>
 
+    <path name="voice-speaker-2-protected">
+        <ctl name="AIF4_VI Mixer SPKR_VI_2" value="1" />
+        <ctl name="SLIM_4_TX Format" value="PACKED_16B" />
+        <path name="speaker-mono-2" />
+        <ctl name="VI_FEED_TX Channels" value="One" />
+        <ctl name="SLIM0_RX_VI_FB_LCH_MUX"  value="SLIM4_TX" />
+    </path>
+
     <path name="vi-feedback">
+    </path>
+
+    <path name="vi-feedback-mono-1">
+    </path>
+
+    <path name="vi-feedback-mono-2">
     </path>
 
     <path name="speaker-protected-vbat">
@@ -2276,6 +2512,11 @@
         <ctl name="RX INT7 VBAT SPKRL VBAT Enable" value="1" />
     </path>
 
+    <path name="voice-speaker-2-protected-vbat">
+        <path name="voice-speaker-2-protected" />
+        <ctl name="RX INT8 VBAT SPKRL VBAT Enable" value="1" />
+    </path>
+
     <path name="handset">
         <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM_0_RX Channels" value="One" />
@@ -2283,7 +2524,7 @@
         <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
         <ctl name="EAR PA Gain" value="G_6_DB" />
         <ctl name="RX0 Digital Volume" value="84" />
-        <ctl name="PM8996_Ear_Enable_States" value="Enable" />
+        <ctl name="Ear_Enable_States" value="Enable" />
     </path>
 
     <path name="handset-mic">
@@ -2327,21 +2568,19 @@
         <ctl name="DMIC MUX6" value="DMIC2" />
         <ctl name="SLIM TX8 MUX" value="DEC8" />
         <ctl name="ADC MUX8" value="DMIC" />
-        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="DMIC MUX8" value="DMIC5" />
     </path>
 
     <path name="anc-handset">
         <ctl name="ANC Function" value="ON" />
+        <ctl name="ANC Slot" value="6" />
         <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM_0_RX Channels" value="One" />
-        <ctl name="RX INT0_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX0 Digital Volume" value="81" />
-        <ctl name="ANC Slot" value="6" />
-        <ctl name="ADC MUX10" value="DMIC" />
-        <ctl name="DMIC MUX10" value="DMIC3" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_EAR" />
-        <ctl name="ANC EAR Enable Switch" value="1" />
+        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
+        <ctl name="ANC OUT EAR SPKR Enable Switch" value="1" />
+        <ctl name="ANC SPKR PA Enable Switch" value="1" />
+        <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
+        <ctl name="SpkrLeft WSA PA Gain" value="G_6_DB" />
     </path>
 
     <path name="headphones">
@@ -2357,18 +2596,40 @@
     </path>
 
     <path name="headphones-44.1">
-        <ctl name="SLIM RX3 MUX" value="AIF3_PB" />
         <ctl name="SLIM RX4 MUX" value="AIF3_PB" />
+        <ctl name="SLIM RX5 MUX" value="AIF3_PB" />
         <ctl name="SLIM_5_RX Channels" value="Two" />
         <ctl name="SLIM_5_RX SampleRate" value="KHZ_44P1" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX3" />
-        <ctl name="RX INT2_1 MIX1 INP1" value="RX4" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX4" />
+        <ctl name="RX INT2_1 MIX1 INP1" value="RX5" />
         <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
         <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
         <ctl name="SPL SRC0 MUX" value="SRC_IN_HPHL" />
         <ctl name="SPL SRC1 MUX" value="SRC_IN_HPHR" />
         <ctl name="RX INT1 SPLINE MIX HPHL Switch" value="1" />
         <ctl name="RX INT2 SPLINE MIX HPHR Switch" value="1" />
+    </path>
+
+
+    <path name="true-native-mode">
+        <ctl name="RX INT1_2 MUX" value="ZERO" />
+        <ctl name="RX INT2_2 MUX" value="ZERO" />
+        <ctl name= "RX INT1_1 MIX1 INP0" value="RX2" />
+        <ctl name= "RX INT2_1 MIX1 INP0" value="RX3" />
+        <ctl name= "RX INT1_1 NATIVE MUX" value="ON" />
+        <ctl name= "RX INT2_1 NATIVE MUX" value="ON" />
+    </path>
+
+    <path name="hph-highquality-mode">
+        <ctl name="RX HPH Mode" value="CLS_H_LOHIFI" />
+    </path>
+
+    <path name="hph-lowpower-mode">
+        <ctl name="RX HPH Mode" value="CLS_H_LP" />
+    </path>
+
+    <path name="line">
+        <path name="headphones" />
     </path>
 
     <path name="headphones-hpf">
@@ -2426,27 +2687,16 @@
         <path name="handset" />
     </path>
 
-    <path name="voice-handset-eq1">
-        <path name="handset" />
-    </path>
-
     <path name="voice-handset-tmus">
         <path name="handset" />
     </path>
 
     <path name="voice-speaker">
-        <ctl name="AIF4_VI Mixer SPKR_VI_2" value="1" />
-        <ctl name="SLIM_4_TX Format" value="PACKED_16B" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="One" />
-        <ctl name="RX INT8_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX8 Digital Volume" value="82" />
-        <ctl name="SpkrRight COMP Switch" value="1" />
-        <ctl name="SpkrRight BOOST Switch" value="1" />
-        <ctl name="SpkrRight VISENSE Switch" value="1" />
-        <ctl name="SpkrRight SWR DAC_Port Switch" value="1" />
-        <ctl name="VI_FEED_TX Channels" value="One" />
-        <ctl name="SLIM0_RX_VI_FB_LCH_MUX"  value="SLIM4_TX" />
+        <path name="speaker-mono" />
+    </path>
+
+    <path name="voice-speaker-2">
+        <path name="speaker-mono-2" />
     </path>
 
     <path name="voice-speaker-fluid">
@@ -2461,10 +2711,17 @@
         <path name="speaker-vbat-mono" />
     </path>
 
+    <path name="voice-speaker-2-vbat">
+        <path name="speaker-vbat-mono-2" />
+    </path>
+
     <path name="voice-headphones">
         <path name="headphones" />
-        <ctl name="RX1 Digital Volume" value="76" />
-        <ctl name="RX2 Digital Volume" value="76" />
+        <ctl name="RX HPH Mode" value="CLS_H_HIFI" />
+    </path>
+
+    <path name="voice-line">
+        <path name="voice-headphones" />
     </path>
 
     <path name="voice-headset-mic">
@@ -2491,6 +2748,10 @@
         <ctl name="Set Custom Stereo" value="Mix" />
     </path>
 
+    <path name="speaker-and-line">
+        <path name="speaker-and-headphones" />
+    </path>
+
     <path name="ringtone-speaker-and-headphones">
         <path name="ringtone-speaker" />
         <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
@@ -2502,77 +2763,55 @@
         <path name="headphones-hpf" />
     </path>
 
-    <path name="ringtone-speaker-mono-and-headphones">
-        <path name="ringtone-speaker-mono" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX1 Digital Volume" value="55" />
-        <ctl name="RX2 Digital Volume" value="55" />
-        <path name="headphones-hpf" />
-    </path>
-
     <path name="speaker-and-headphones-liquid">
         <path name="headphones" />
-        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT8_1 MIX1 INP0" value="RX1" />
-        <ctl name="SpkrLeft COMP Switch" value="1" />
-        <ctl name="SpkrRight COMP Switch" value="1" />
-        <ctl name="SpkrLeft BOOST Switch" value="1" />
-        <ctl name="SpkrRight BOOST Switch" value="1" />
-        <ctl name="SpkrLeft VISENSE Switch" value="1" />
-        <ctl name="SpkrRight VISENSE Switch" value="1" />
-        <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
-        <ctl name="SpkrRight SWR DAC_Port Switch" value="1" />
+        <path name="speaker" />
+    </path>
+
+    <path name="speaker-and-line-liquid">
+        <path name="speaker-and-headphones-liquid" />
     </path>
 
     <path name="usb-headphones">
+    </path>
+
+    <path name="usb-headset">
     </path>
 
     <path name="afe-proxy">
     </path>
 
     <path name="anc-headphones">
-	<ctl name="COMP1 Switch" value="0" />
-	<ctl name="COMP2 Switch" value="0" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
         <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="HPHL Volume" value="14" />
-        <ctl name="HPHR Volume" value="14" />
-        <ctl name="RX1 Digital Volume" value="81" />
-        <ctl name="RX2 Digital Volume" value="81" />
         <ctl name="ANC Slot" value="0" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
         <ctl name="ADC MUX10" value="AMIC" />
         <ctl name="AMIC MUX10" value="ADC3" />
         <ctl name="ADC MUX12" value="AMIC" />
         <ctl name="AMIC MUX12" value="ADC4" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
         <ctl name="ADC3 Volume" value="8" />
         <ctl name="ADC4 Volume" value="8" />
+        <ctl name="SLIM RX2 MUX" value="AIF4_PB" />
+        <ctl name="SLIM RX3 MUX" value="AIF4_PB" />
+        <ctl name="SLIM_6_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX2" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX3" />
+        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="RX1 Digital Volume" value="81" />
+        <ctl name="RX2 Digital Volume" value="81" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+        <ctl name="HPHL Volume" value="14" />
+        <ctl name="HPHR Volume" value="14" />
     </path>
 
     <path name="speaker-and-anc-headphones">
         <path name="anc-headphones" />
-        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT8_1 MIX1 INP0" value="RX1" />
-        <ctl name="SpkrLeft COMP Switch" value="1" />
-        <ctl name="SpkrRight COMP Switch" value="1" />
-        <ctl name="SpkrLeft BOOST Switch" value="1" />
-        <ctl name="SpkrRight BOOST Switch" value="1" />
-        <ctl name="SpkrLeft VISENSE Switch" value="1" />
-        <ctl name="SpkrRight VISENSE Switch" value="1" />
-        <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
-        <ctl name="SpkrRight SWR DAC_Port Switch" value="1" />
+        <path name="speaker" />
     </path>
 
     <path name="anc-fb-headphones">
@@ -2582,27 +2821,27 @@
 
     <path name="speaker-and-anc-fb-headphones">
         <path name="anc-fb-headphones" />
-        <ctl name="RX INT7_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT8_1 MIX1 INP0" value="RX1" />
-        <ctl name="SpkrLeft COMP Switch" value="1" />
-        <ctl name="SpkrRight COMP Switch" value="1" />
-        <ctl name="SpkrLeft BOOST Switch" value="1" />
-        <ctl name="SpkrRight BOOST Switch" value="1" />
-        <ctl name="SpkrLeft VISENSE Switch" value="1" />
-        <ctl name="SpkrRight VISENSE Switch" value="1" />
-        <ctl name="SpkrLeft SWR DAC_Port Switch" value="1" />
-        <ctl name="SpkrRight SWR DAC_Port Switch" value="1" />
+        <path name="speaker" />
     </path>
 
     <path name="voice-anc-headphones">
-	<ctl name="COMP1 Switch" value="0" />
-	<ctl name="COMP2 Switch" value="0" />
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
         <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="ANC Slot" value="0" />
+        <ctl name="ADC MUX10" value="AMIC" />
+        <ctl name="AMIC MUX10" value="ADC3" />
+        <ctl name="ADC MUX12" value="AMIC" />
+        <ctl name="AMIC MUX12" value="ADC4" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ADC3 Volume" value="8" />
+        <ctl name="ADC4 Volume" value="8" />
+        <ctl name="SLIM RX2 MUX" value="AIF4_PB" />
+        <ctl name="SLIM RX3 MUX" value="AIF4_PB" />
+        <ctl name="SLIM_6_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX2" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX3" />
         <ctl name="RX HPH Mode" value="CLS_H_LP" />
         <ctl name="IIR0 Enable Band1" value="1" />
         <ctl name="IIR0 Enable Band2" value="1" />
@@ -2612,32 +2851,32 @@
         <ctl name="IIR0 INP0 Volume" value="54" />
         <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
         <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="HPHL Volume" value="14" />
-        <ctl name="HPHR Volume" value="14" />
         <ctl name="RX1 Digital Volume" value="81" />
         <ctl name="RX2 Digital Volume" value="81" />
-        <ctl name="ANC Slot" value="0" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
+        <ctl name="ANC HPHL Enable Switch" value="1" />
+        <ctl name="ANC HPHR Enable Switch" value="1" />
+        <ctl name="HPHL Volume" value="14" />
+        <ctl name="HPHR Volume" value="14" />
+    </path>
+
+    <path name="voice-anc-fb-headphones">
+        <ctl name="COMP1 Switch" value="0" />
+        <ctl name="COMP2 Switch" value="0" />
+        <ctl name="ANC Function" value="ON" />
+        <ctl name="ANC Slot" value="1" />
         <ctl name="ADC MUX10" value="AMIC" />
         <ctl name="AMIC MUX10" value="ADC3" />
         <ctl name="ADC MUX12" value="AMIC" />
         <ctl name="AMIC MUX12" value="ADC4" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
+        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
         <ctl name="ADC3 Volume" value="8" />
         <ctl name="ADC4 Volume" value="8" />
-    </path>
-
-    <path name="voice-anc-fb-headphones">
-	<ctl name="COMP1 Switch" value="0" />
-	<ctl name="COMP2 Switch" value="0" />
-        <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+        <ctl name="SLIM RX2 MUX" value="AIF4_PB" />
+        <ctl name="SLIM RX3 MUX" value="AIF4_PB" />
+        <ctl name="SLIM_6_RX Channels" value="Two" />
+        <ctl name="RX INT1_1 MIX1 INP0" value="RX2" />
+        <ctl name="RX INT2_1 MIX1 INP0" value="RX3" />
         <ctl name="RX HPH Mode" value="CLS_H_LP" />
         <ctl name="IIR0 Enable Band1" value="1" />
         <ctl name="IIR0 Enable Band2" value="1" />
@@ -2647,21 +2886,12 @@
         <ctl name="IIR0 INP0 Volume" value="62" />
         <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
         <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="HPHL Volume" value="14" />
-        <ctl name="HPHR Volume" value="14" />
         <ctl name="RX1 Digital Volume" value="81" />
         <ctl name="RX2 Digital Volume" value="81" />
-        <ctl name="ANC Slot" value="1" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
-        <ctl name="ADC MUX10" value="AMIC" />
-        <ctl name="AMIC MUX10" value="ADC3" />
-        <ctl name="ADC MUX12" value="AMIC" />
-        <ctl name="AMIC MUX12" value="ADC4" />
         <ctl name="ANC HPHL Enable Switch" value="1" />
         <ctl name="ANC HPHR Enable Switch" value="1" />
-        <ctl name="ADC3 Volume" value="8" />
-        <ctl name="ADC4 Volume" value="8" />
+        <ctl name="HPHL Volume" value="14" />
+        <ctl name="HPHR Volume" value="14" />
     </path>
 
     <path name="speaker-and-anc-headphones-liquid">
@@ -2669,6 +2899,9 @@
     </path>
 
     <path name="hdmi">
+    </path>
+
+    <path name="display-port">
     </path>
 
     <path name="speaker-and-usb-headphones">
@@ -2681,22 +2914,23 @@
         <path name="hdmi" />
     </path>
 
-    <path name="voice-rec-mic">
-        <path name="handset-mic" />
+    <path name="speaker-and-display-port">
+        <path name="speaker" />
+        <path name="display-port" />
     </path>
 
     <path name="camcorder-mic-common">
-        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1" />
-        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
+        <ctl name="AIF1_CAP Mixer SLIM TX7" value="1"/>
+        <ctl name="AIF1_CAP Mixer SLIM TX8" value="1"/>
         <ctl name="SLIM_0_TX Channels" value="Two" />
         <ctl name="TX8 HPF cut off" value="CF_NEG_3DB_4HZ" />
         <ctl name="TX7 HPF cut off" value="CF_NEG_3DB_4HZ" />
         <ctl name="SLIM TX7 MUX" value="DEC7" />
         <ctl name="SLIM TX8 MUX" value="DEC8" />
-        <ctl name="ADC MUX8" value="DMIC" />
-        <ctl name="DMIC MUX8" value="DMIC0" />
         <ctl name="ADC MUX7" value="DMIC" />
         <ctl name="DMIC MUX7" value="DMIC3" />
+        <ctl name="ADC MUX8" value="DMIC" />
+        <ctl name="DMIC MUX8" value="DMIC0" />
         <ctl name="SLIM_0_TX Format" value="S24_LE" />
     </path>
 
@@ -2807,6 +3041,12 @@
         <ctl name="SLIM_0_TX Channels" value="Two" />
     </path>
 
+    <path name="aanc-path">
+        <ctl name="ADC MUX10" value="DMIC" />
+        <ctl name="DMIC MUX10" value="DMIC4" />
+        <ctl name="ANC0 FB MUX" value="ANC_IN_EAR_SPKR" />
+    </path>
+
     <path name="aanc-handset-mic">
         <ctl name="AIF1_CAP Mixer SLIM TX6" value="1" />
         <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
@@ -2815,13 +3055,13 @@
         <ctl name="AANC_SLIM_0_RX MUX" value="SLIMBUS_0_TX" />
         <ctl name="SLIM TX6 MUX" value="DEC6" />
         <ctl name="ADC MUX6" value="DMIC" />
-        <ctl name="DMIC MUX6" value="DMIC0" />
+        <ctl name="DMIC MUX6" value="DMIC2" />
         <ctl name="SLIM TX8 MUX" value="DEC8" />
         <ctl name="ADC MUX8" value="DMIC" />
-        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="DMIC MUX8" value="DMIC4" />
         <ctl name="SLIM TX9 MUX" value="DEC7" />
         <ctl name="ADC MUX7" value="DMIC" />
-        <ctl name="DMIC MUX7" value="DMIC2" />
+        <ctl name="DMIC MUX7" value="DMIC0" />
         <ctl name="IIR0 INP0 MUX" value="DEC6" />
     </path>
 
@@ -2845,10 +3085,10 @@
         <ctl name="AIF1_CAP Mixer SLIM TX8" value="1" />
         <ctl name="SLIM TX7 MUX" value="DEC7" />
         <ctl name="ADC MUX7" value="DMIC" />
-        <ctl name="DMIC MUX7" value="DMIC2" />
+        <ctl name="DMIC MUX7" value="DMIC1" />
         <ctl name="SLIM TX8 MUX" value="DEC8" />
         <ctl name="ADC MUX8" value="DMIC" />
-        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="DMIC MUX8" value="DMIC5" />
         <ctl name="SLIM_0_TX Channels" value="Two" />
     </path>
 
@@ -3073,7 +3313,7 @@
         <ctl name="SLIM_0_TX Channels" value="Two" />
         <ctl name="SLIM TX7 MUX" value="DEC7" />
         <ctl name="ADC MUX7" value="DMIC" />
-        <ctl name="DMIC MUX7" value="DMIC0" />
+        <ctl name="DMIC MUX7" value="DMIC1" />
         <ctl name="SLIM TX8 MUX" value="DEC8" />
         <ctl name="ADC MUX8" value="DMIC" />
         <ctl name="DMIC MUX8" value="DMIC2" />
@@ -3142,16 +3382,16 @@
         <ctl name="SLIM_0_TX Channels" value="Four" />
         <ctl name="SLIM TX5 MUX" value="DEC5" />
         <ctl name="ADC MUX5" value="DMIC" />
-        <ctl name="DMIC MUX5" value="DMIC0" />
+        <ctl name="DMIC MUX5" value="DMIC1" />
         <ctl name="SLIM TX6 MUX" value="DEC6" />
         <ctl name="ADC MUX6" value="DMIC" />
-        <ctl name="DMIC MUX6" value="DMIC2" />
+        <ctl name="DMIC MUX6" value="DMIC0" />
         <ctl name="SLIM TX7 MUX" value="DEC7" />
         <ctl name="ADC MUX7" value="DMIC" />
-        <ctl name="DMIC MUX7" value="DMIC1" />
+        <ctl name="DMIC MUX7" value="DMIC2" />
         <ctl name="SLIM TX8 MUX" value="DEC8" />
         <ctl name="ADC MUX8" value="DMIC" />
-        <ctl name="DMIC MUX8" value="DMIC3" />
+        <ctl name="DMIC MUX8" value="DMIC5" />
     </path>
 
     <path name="speaker-qmic-liquid">
@@ -3227,9 +3467,9 @@
         <path name="handset" />
     </path>
 
-    <path name="voice-tty-hco-speaker">
+    <path name="voice-tty-hco-speaker-2-protected">
         <ctl name="TTY Mode" value="HCO" />
-        <path name="voice-speaker" />
+        <path name="voice-speaker-2-protected" />
     </path>
 
     <path name="voice-tty-full-headset-mic">
@@ -3259,6 +3499,14 @@
         <path name="incall-music" />
     </path>
 
+    <path name="incall-music-usb-headphones">
+        <path name="incall-music" />
+    </path>
+
+    <path name="incall-music-usb-headset">
+        <path name="incall-music" />
+    </path>
+
     <path name="incall-music2">
         <path name="incall-music" />
     </path>
@@ -3271,33 +3519,33 @@
         <path name="incall-music2" />
     </path>
 
+    <path name="incall-music2-usb-headphones">
+        <path name="incall-music2" />
+    </path>
+
+    <path name="incall-music2-usb-headset">
+        <path name="incall-music2" />
+    </path>
+
     <path name="listen-handset-mic">
         <ctl name="MADONOFF Switch" value="1" />
-        <ctl name="MAD Input" value="DMIC0" />
+        <ctl name="MAD Input" value="DMIC2" />
+    </path>
+
+    <path name="unprocessed-handset-mic">
+        <path name="handset-mic" />
+    </path>
+
+    <path name="unprocessed-mic">
+        <path name="unprocessed-handset-mic" />
     </path>
 
     <path name="unprocessed-headset-mic">
         <path name="headset-mic" />
     </path>
 
-    <path name="unprocessed-mic">
-        <path name="handset-mic" />
-    </path>
-
     <path name="unprocessed-stereo-mic">
         <path name="stereo-mic" />
-    </path>
-
-    <path name="set-capture-format-24le">
-        <ctl name="SLIM_0_TX Format" value="S24_LE" />
-    </path>
-
-    <path name="set-capture-format-16le">
-        <ctl name="SLIM_0_TX Format" value="S16_LE" />
-    </path>
-
-    <path name="set-capture-format-default">
-        <path name="set-capture-format-16le" />
     </path>
 
     <!-- Added for ADSP testfwk -->
@@ -3305,10 +3553,123 @@
         <ctl name="SLIMBUS_DL_HL Switch" value="1" />
     </path>
 
-    <path name="voice-rx">
+    <path name="bt-a2dp">
+        <ctl name="BT SampleRate" value="KHZ_48" />
+        <ctl name="AFE Input Channels" value="Two" />
+        <ctl name="SLIM7_RX ADM Channels" value="Two" />
     </path>
 
-    <path name="voice-tx">
+    <path name="speaker-and-bt-a2dp">
+        <path name="speaker" />
+        <path name="bt-a2dp" />
+    </path>
+
+    <path name="deep-buffer-playback bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia1" value="1" />
+    </path>
+
+    <path name="low-latency-playback bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia5" value="1" />
+    </path>
+
+    <path name="compress-offload-playback bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia4" value="1" />
+    </path>
+
+    <path name="compress-offload-playback2 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia7" value="1" />
+    </path>
+
+    <path name="compress-offload-playback3 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia10" value="1" />
+    </path>
+
+    <path name="compress-offload-playback4 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia11" value="1" />
+    </path>
+
+    <path name="compress-offload-playback5 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia12" value="1" />
+    </path>
+
+    <path name="compress-offload-playback6 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia13" value="1" />
+    </path>
+
+    <path name="compress-offload-playback7 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia14" value="1" />
+    </path>
+
+    <path name="compress-offload-playback8 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia15" value="1" />
+    </path>
+
+    <path name="compress-offload-playback9 bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia16" value="1" />
+    </path>
+
+    <path name="audio-ull-playback bt-a2dp">
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia3" value="1" />
+    </path>
+
+    <path name="deep-buffer-playback speaker-and-bt-a2dp">
+        <path name="deep-buffer-playback bt-a2dp" />
+        <path name="deep-buffer-playback" />
+    </path>
+
+    <path name="compress-offload-playback speaker-and-bt-a2dp">
+        <path name="compress-offload-playback bt-a2dp" />
+        <path name="compress-offload-playback" />
+    </path>
+
+    <path name="low-latency-playback speaker-and-bt-a2dp">
+        <path name="low-latency-playback bt-a2dp" />
+        <path name="low-latency-playback" />
+    </path>
+
+    <path name="compress-offload-playback2 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback2 bt-a2dp" />
+        <path name="compress-offload-playback2" />
+    </path>
+
+    <path name="compress-offload-playback3 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback3 bt-a2dp" />
+        <path name="compress-offload-playback3" />
+    </path>
+
+    <path name="compress-offload-playback4 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback4 bt-a2dp" />
+        <path name="compress-offload-playback4" />
+    </path>
+
+    <path name="compress-offload-playback5 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback5 bt-a2dp" />
+        <path name="compress-offload-playback5" />
+    </path>
+
+    <path name="compress-offload-playback6 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback6 bt-a2dp" />
+        <path name="compress-offload-playback6" />
+    </path>
+
+    <path name="compress-offload-playback7 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback7 bt-a2dp" />
+        <path name="compress-offload-playback7" />
+    </path>
+
+    <path name="compress-offload-playback8 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback8 bt-a2dp" />
+        <path name="compress-offload-playback8" />
+    </path>
+
+    <path name="compress-offload-playback9 speaker-and-bt-a2dp">
+        <path name="compress-offload-playback9 bt-a2dp" />
+        <path name="compress-offload-playback9" />
+    </path>
+
+    <path name="audio-ull-playback speaker-and-bt-a2dp">
+        <path name="audio-ull-playback bt-a2dp" />
+        <path name="audio-ull-playback" />
     </path>
 
     <!-- ********************************************* -->
@@ -3335,39 +3696,18 @@
         <ctl name="AMIC MUX10" value="ZERO" />
         <ctl name="ADC MUX12" value="ZERO" />
         <ctl name="AMIC MUX12" value="ZERO" />
+        <ctl name="RX2 Digital Volume" value="84" />
+        <ctl name="RX1 Digital Volume" value="84" />
         <ctl name="ADC3 Volume" value="10" />
         <ctl name="ADC2 Volume" value="10" />
-        <ctl name="ANC0 FB MUX" value="ZERO" />
         <ctl name="ANC1 FB MUX" value="ZERO" />
+        <ctl name="ANC0 FB MUX" value="ZERO" />
+        <ctl name="ANC Function" value="OFF" />
         <ctl name="ANC HPHL Enable Switch" value="0" />
         <ctl name="ANC HPHR Enable Switch" value="0" />
-        <ctl name="ANC Function" value="OFF" />
     </path>
 
     <path name="anc-on">
-        <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="84" />
-        <ctl name="RX2 Digital Volume" value="84" />
-        <ctl name="ADC3 Volume" value="10" />
-        <ctl name="ADC2 Volume" value="10" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
-    </path>
-
-    <path name="anc-on-regulation">
         <ctl name="ANC Function" value="ON" />
         <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
@@ -3390,34 +3730,7 @@
         <ctl name="ANC HPHR Enable Switch" value="1" />
     </path>
 
-    <path name="anc2-off">
-        <path name="anc-off" />
-    </path>
-
     <path name="anc2-on">
-        <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="84" />
-        <ctl name="RX2 Digital Volume" value="84" />
-        <ctl name="ADC3 Volume" value="10" />
-        <ctl name="ADC2 Volume" value="10" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
-    </path>
-
-    <path name="anc2-on-regulation">
         <ctl name="ANC Function" value="ON" />
         <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
@@ -3454,22 +3767,6 @@
         <ctl name="COMP2 Switch" value="0" />
         <ctl name="HPHL Volume" value="20" />
         <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="84" />
-        <ctl name="RX2 Digital Volume" value="84" />
-    </path>
-
-    <path name="anc-off-headphone-regulation">
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
         <ctl name="RX1 Digital Volume" value="77" />
         <ctl name="RX2 Digital Volume" value="77" />
     </path>
@@ -3487,139 +3784,11 @@
         <ctl name="RX2 Digital Volume" value="84" />
     </path>
 
-    <!-- ====================================================== -->
-    <!--  common sequence for non call devices for pcm offload  -->
-    <!-- ====================================================== -->
-
-    <path name="anc-off-pcm-offload">
-        <ctl name="ADC MUX10" value="ZERO" />
-        <ctl name="AMIC MUX10" value="ZERO" />
-        <ctl name="ADC MUX12" value="ZERO" />
-        <ctl name="AMIC MUX12" value="ZERO" />
-        <ctl name="ADC3 Volume" value="0" />
-        <ctl name="ADC2 Volume" value="0" />
-        <ctl name="ANC0 FB MUX" value="ZERO" />
-        <ctl name="ANC1 FB MUX" value="ZERO" />
-        <ctl name="ANC Function" value="OFF" />
-    </path>
-
-    <path name="anc-on-pcm-offload">
-        <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="84" />
-        <ctl name="RX2 Digital Volume" value="84" />
-        <ctl name="ADC3 Volume" value="10" />
-        <ctl name="ADC2 Volume" value="10" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
-    </path>
-
-    <path name="anc-on-pcm-offload-regulation">
-        <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="77" />
-        <ctl name="RX2 Digital Volume" value="77" />
-        <ctl name="ADC3 Volume" value="10" />
-        <ctl name="ADC2 Volume" value="10" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
-    </path>
-
-    <path name="anc2-off-pcm-offload">
-        <path name="anc-off-pcm-offload" />
-    </path>
-
-    <path name="anc2-on-pcm-offload">
-        <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="84" />
-        <ctl name="RX2 Digital Volume" value="84" />
-        <ctl name="ADC3 Volume" value="10" />
-        <ctl name="ADC2 Volume" value="10" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
-    </path>
-
-    <path name="anc2-on-pcm-offload-regulation">
-        <ctl name="ANC Function" value="ON" />
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="77" />
-        <ctl name="RX2 Digital Volume" value="77" />
-        <ctl name="ADC3 Volume" value="10" />
-        <ctl name="ADC2 Volume" value="10" />
-        <ctl name="ANC0 FB MUX" value="ANC_IN_HPHL" />
-        <ctl name="ANC1 FB MUX" value="ANC_IN_HPHR" />
-        <ctl name="ANC HPHL Enable Switch" value="1" />
-        <ctl name="ANC HPHR Enable Switch" value="1" />
-    </path>
-
     <!-- ============================================= -->
     <!--    common sequence for call devices           -->
     <!-- ============================================= -->
 
     <path name="voiceanc-headphone">
-        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
-        <ctl name="SLIM_0_RX Channels" value="Two" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX0" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT1 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="RX INT2 DEM MUX" value="CLSH_DSM_OUT" />
-        <ctl name="COMP1 Switch" value="0" />
-        <ctl name="COMP2 Switch" value="0" />
-        <ctl name="HPHL Volume" value="20" />
-        <ctl name="HPHR Volume" value="20" />
-        <ctl name="RX1 Digital Volume" value="83" />
-        <ctl name="RX2 Digital Volume" value="83" />
-    </path>
-
-    <path name="voiceanc-headphone-eq1">
         <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM RX1 MUX" value="AIF_MIX1_PB" />
         <ctl name="SLIM_0_RX Channels" value="Two" />
@@ -3712,15 +3881,8 @@
     <path name="anc-nc-headphone">
     </path>
 
-    <path name="anc-nc-headphone-regulation">
-    </path>
-
     <path name="anc-nc-off-headphone">
         <path name="anc-off-headphone" />
-    </path>
-
-    <path name="anc-nc-off-headphone-regulation">
-        <path name="anc-off-headphone-regulation" />
     </path>
 
     <path name="speaker-anc-nc-headphone">
@@ -3741,24 +3903,6 @@
         <ctl name="RX2 Digital Volume" value="50" />
         <path name="headphones-hpf" />
         <ctl name="Set Custom Stereo" value="Mix" />
-    </path>
-
-    <path name="speaker-mono-ring-anc-nc-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc-nc-headphone" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX1 Digital Volume" value="50" />
-        <ctl name="RX2 Digital Volume" value="50" />
-        <path name="headphones-hpf" />
-    </path>
-
-    <path name="speaker-mono-ring-anc-nc-off-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc-off-headphone-combo" />
-        <ctl name="RX1 Digital Volume" value="50" />
-        <ctl name="RX2 Digital Volume" value="50" />
-        <path name="headphones-hpf" />
     </path>
 
     <path name="speaker-ring-anc-nc-headphone">
@@ -3785,26 +3929,13 @@
         <ctl name="RX2 Digital Volume" value="78" />
     </path>
 
-    <path name="voiceanc-nc-headphone-eq1">
-        <path name="voiceanc-headphone-eq1" />
-        <ctl name="RX1 Digital Volume" value="78" />
-        <ctl name="RX2 Digital Volume" value="78" />
-    </path>
-
     <!-- ========  NCE  ======== -->
 
     <path name="anc-nce-headphone">
     </path>
 
-    <path name="anc-nce-headphone-regulation">
-    </path>
-
     <path name="anc-nce-off-headphone">
         <path name="anc-off-headphone" />
-    </path>
-
-    <path name="anc-nce-off-headphone-regulation">
-        <path name="anc-off-headphone-regulation" />
     </path>
 
     <path name="speaker-anc-nce-headphone">
@@ -3825,24 +3956,6 @@
         <ctl name="RX2 Digital Volume" value="56" />
         <path name="headphones-hpf" />
         <ctl name="Set Custom Stereo" value="Mix" />
-    </path>
-
-    <path name="speaker-mono-ring-anc-nce-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc-nce-headphone" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX1 Digital Volume" value="56" />
-        <ctl name="RX2 Digital Volume" value="56" />
-        <path name="headphones-hpf" />
-    </path>
-
-    <path name="speaker-mono-ring-anc-nce-off-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc-off-headphone-combo" />
-        <ctl name="RX1 Digital Volume" value="56" />
-        <ctl name="RX2 Digital Volume" value="56" />
-        <path name="headphones-hpf" />
     </path>
 
     <path name="speaker-ring-anc-nce-headphone">
@@ -3867,24 +3980,13 @@
         <path name="voiceanc-headphone" />
     </path>
 
-    <path name="voiceanc-nce-headphone-eq1">
-        <path name="voiceanc-headphone-eq1" />
-    </path>
-
     <!-- ========  ANC2 NC  ======== -->
 
     <path name="anc2-nc-headphone">
     </path>
 
-    <path name="anc2-nc-headphone-regulation">
-    </path>
-
     <path name="anc2-nc-off-headphone">
         <path name="anc-off-headphone" />
-    </path>
-
-    <path name="anc2-nc-off-headphone-regulation">
-        <path name="anc-off-headphone-regulation" />
     </path>
 
     <path name="speaker-anc2-nc-headphone">
@@ -3905,24 +4007,6 @@
         <ctl name="RX2 Digital Volume" value="50" />
         <path name="headphones-hpf" />
         <ctl name="Set Custom Stereo" value="Mix" />
-    </path>
-
-    <path name="speaker-mono-ring-anc2-nc-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc2-nc-headphone" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX1 Digital Volume" value="50" />
-        <ctl name="RX2 Digital Volume" value="50" />
-        <path name="headphones-hpf" />
-    </path>
-
-    <path name="speaker-mono-ring-anc2-nc-off-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc-off-headphone-combo" />
-        <ctl name="RX1 Digital Volume" value="50" />
-        <ctl name="RX2 Digital Volume" value="50" />
-        <path name="headphones-hpf" />
     </path>
 
     <path name="speaker-ring-anc2-nc-headphone">
@@ -3949,26 +4033,13 @@
         <ctl name="RX2 Digital Volume" value="78" />
     </path>
 
-    <path name="voiceanc2-nc-headphone-eq1">
-        <path name="voiceanc-headphone-eq1" />
-        <ctl name="RX1 Digital Volume" value="78" />
-        <ctl name="RX2 Digital Volume" value="78" />
-    </path>
-
     <!-- ========  ANC2 NCE  ======== -->
 
     <path name="anc2-nce-headphone">
     </path>
 
-    <path name="anc2-nce-headphone-regulation">
-    </path>
-
     <path name="anc2-nce-off-headphone">
         <path name="anc-off-headphone" />
-    </path>
-
-    <path name="anc2-nce-off-headphone-regulation">
-        <path name="anc-off-headphone-regulation" />
     </path>
 
     <path name="speaker-anc2-nce-headphone">
@@ -3991,24 +4062,6 @@
         <ctl name="Set Custom Stereo" value="Mix" />
     </path>
 
-    <path name="speaker-mono-ring-anc2-nce-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc2-nce-headphone" />
-        <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
-        <ctl name="RX1 Digital Volume" value="56" />
-        <ctl name="RX2 Digital Volume" value="56" />
-        <path name="headphones-hpf" />
-    </path>
-
-    <path name="speaker-mono-ring-anc2-nce-off-headphone">
-        <path name="ringtone-speaker-mono" />
-        <path name="anc-off-headphone-combo" />
-        <ctl name="RX1 Digital Volume" value="56" />
-        <ctl name="RX2 Digital Volume" value="56" />
-        <path name="headphones-hpf" />
-    </path>
-
     <path name="speaker-ring-anc2-nce-headphone">
         <path name="ringtone-speaker" />
         <path name="anc2-nce-headphone" />
@@ -4029,10 +4082,6 @@
 
     <path name="voiceanc2-nce-headphone">
         <path name="voiceanc-headphone" />
-    </path>
-
-    <path name="voiceanc2-nce-headphone-eq1">
-        <path name="voiceanc-headphone-eq1" />
     </path>
 
     <!-- ============================================= -->
@@ -4123,16 +4172,6 @@
 
     <!-- ========  no use  ======== -->
 
-    <path name="anc-type-voice-anc-headphone-mode">
-        <ctl name="ANC Slot" value="6" />
-        <path name="anc-mux-on" />
-    </path>
-
-    <path name="anc-type-voice-anc-headphone-eq1-mode">
-        <ctl name="ANC Slot" value="7" />
-        <path name="anc-mux-on" />
-    </path>
-
     <path name="anc-rx-inp-mix1-off">
         <ctl name="RX INT1_1 MIX1 INP0" value="ZERO" />
         <ctl name="RX INT2_1 MIX1 INP0" value="ZERO" />
@@ -4157,8 +4196,8 @@
     </path>
 
     <path name="anc-dec-vol-zero">
-        <ctl name="DEC7 Volume" value="0" />
-        <ctl name="DEC8 Volume" value="0" />
+        <ctl name="DEC4 Volume" value="0" />
+        <ctl name="DEC5 Volume" value="0" />
     </path>
 
     <path name="anc-preparation-rx">
@@ -4175,6 +4214,11 @@
         <ctl name="SLIM_0_RX Channels" value="Two" />
         <ctl name="RX INT1_1 MIX1 INP0" value="RX1" />
         <ctl name="RX INT2_1 MIX1 INP0" value="RX1" />
+    </path>
+
+    <path name="anc-playback-volume">
+        <ctl name="RX1 Digital Volume" value="77" />
+        <ctl name="RX2 Digital Volume" value="77" />
     </path>
 
 </mixer>


### PR DESCRIPTION
This is the correct mixer_paths for msm8998-tasha-snd-card.



VERIFY ME. In call audio from loudspeaker and handset works with ACDB. Headphones DO NOT WORK.