### PR TITLE
maple: add missing voice-rec-mic snd_device

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -2781,6 +2781,10 @@
     <path name="afe-proxy">
     </path>
 
+    <path name="voice-rec-mic">
+        <path name="handset-mic" />
+    </path>
+
     <path name="anc-headphones">
         <ctl name="COMP1 Switch" value="0" />
         <ctl name="COMP2 Switch" value="0" />


### PR DESCRIPTION
voice-rec-mic is used by some cases as OK GOOGLE ... this fixes it

Signed-off-by: David Viteri <davidteri91@gmail.com>