### PR TITLE
[MAPLE] Integrate the Camera Augmented Sensing Helper and its ToF calibration

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -39,4 +39,6 @@ TARGET_COPY_OUT_VENDOR := system/vendor
 
 BOARD_ROOT_EXTRA_SYMLINKS := /system/vendor/lib/dsp:/dsp
 
+TARGET_USES_CASH_EXTENSION := true
+
 #TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"

--- a/device.mk
+++ b/device.mk
@@ -52,6 +52,10 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Headset_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Headset_cal.acdb \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Speaker_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Speaker_cal.acdb
 
+# Focus calibration
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/etc/tof_focus_calibration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/tof_focus_calibration.xml
+
 # NFC Configuration
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/libnfc-brcm.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-brcm.conf \
@@ -83,6 +87,12 @@ PRODUCT_PACKAGES += \
 # SAR
 PRODUCT_PACKAGES += \
     TransPowerSensors
+
+# Camera Augmented Sensing Helper
+PRODUCT_PACKAGES += \
+   libpolyreg \
+   cashsvr \
+   libcashctl
 
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi

--- a/rootdir/vendor/etc/tof_focus_calibration.xml
+++ b/rootdir/vendor/etc/tof_focus_calibration.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<tof_focus_calibration>
+    <tof_focus>
+        <focus millimeters="818 690 596 509 439 361 282 189 164 142 126 118 105 94 85"
+               focus_step="1880926 1967332 2106374 2117769 2139239 2545052
+                           3198294 4335333 4684007 5156470 5388361 5529230
+                           5791438 6222752 6672760"/>
+        <polyreg_tuning degree="7" extra="0"/>
+        <ranging_limits min_range="0" max_range="820"/>
+    </tof_focus>
+</tof_focus_calibration>


### PR DESCRIPTION
Add libcashctl, cashsvr, libpolyreg to the build, declare
TARGET_USES_CASH_EXTENSION to build the code in the camera HAL
and copy the tof_focus_calibration XML.