### PR TITLE
add logic to set TARGET_BOOTLOADER_BOARD_NAME

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -14,7 +14,14 @@
 
 include device/sony/yoshino/PlatformConfig.mk
 
-TARGET_BOOTLOADER_BOARD_NAME := yoshino
+TARGET_BOOTLOADER_BOARD_NAME := unknown
+ifneq (,$(filter %g8141,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := G8141
+else ifneq (,$(filter %g8142,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := G8142
+else
+$(error Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)")
+endif
 
 # NFC
 NXP_CHIP_TYPE := PN553


### PR DESCRIPTION
Set TARGET_BOOTLOADER_BOARD_NAME to the variant-specific board-name
(e.g. G8141, G8142).  This causes the "board" variable in
"android-info.txt" to be set correctly, which fixes
updatepackage zips.