### PR TITLE
override fstab.yoshino

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Override fstab.yoshino due to
+# no /vendor partition for maple
+# twrp will try to mount /vendor
+TARGET_RECOVERY_FSTAB ?= device/sony/maple/rootdir/vendor/etc/fstab.maple
+
 include device/sony/yoshino/PlatformConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := unknown

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,0 +1,10 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := fstab.maple
+LOCAL_SRC_FILES := vendor/etc/fstab.maple
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_STEM := fstab.maple
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc
+include $(BUILD_PREBUILT)

--- a/rootdir/vendor/etc/fstab.maple
+++ b/rootdir/vendor/etc/fstab.maple
@@ -1,0 +1,20 @@
+# Android fstab file.
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,recoveryonly
+/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
+/dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/dsp          /dsp         ext4    nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic   wait,notrim
+/dev/block/bootdevice/by-name/misc         /misc        emmc    defaults                                                      defaults
+/dev/block/bootdevice/by-name/modem        /firmware    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0 wait
+/dev/block/bootdevice/by-name/bluetooth    /bt_firmware vfat    ro,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:bt_firmware_file:s0 wait
+/dev/block/bootdevice/by-name/persist      /persist     ext4    noatime,nosuid,nodev,barrier=1,data=ordered,nodelalloc,errors=panic wait,notrim
+
+/devices/soc/c0a4900.sdhci/mmc_host/mmc*                       auto         auto    nosuid,nodev                              voldmanaged=sdcard1:auto
+/devices/soc/a800000.ssusb/a800000.dwc3/xhci-hcd.0.auto/usb*   auto         auto    defaults                                  voldmanaged=usb:auto
+/dev/block/zram0                                               none         swap    defaults                                  zramsize=536870912,notrim


### PR DESCRIPTION
this has not much effect with aosp recovery but custom recoveries like TWRP are trying to mount
/vendor partition also recovery.fstab and twrp.fstab are needed to create mtab

Signed-off-by: David Viteri <davidteri91@gmail.com>