### PR TITLE
[MAPLE] device: Move CASH to device-sony-yoshino

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -42,6 +42,4 @@ BOARD_USERDATAIMAGE_PARTITION_SIZE := 54587727872
 # Device witout a vendor partition
 TARGET_COPY_OUT_VENDOR := system/vendor
 
-TARGET_USES_CASH_EXTENSION := true
-
 #TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"

--- a/device.mk
+++ b/device.mk
@@ -83,12 +83,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     TransPowerSensors
 
-# Camera Augmented Sensing Helper
-PRODUCT_PACKAGES += \
-   libpolyreg \
-   cashsvr \
-   libcashctl
-
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi


### PR DESCRIPTION
All the Yoshino devices are calibrated and all support CASH:
it makes no sense to keep it per-device.