### PR TITLE
config.xml: Reduce minimum brightness

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -31,6 +31,7 @@
 
          Must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLevels">
+        <item>32</item>
         <item>64</item>
         <item>128</item>
         <item>170</item>
@@ -50,7 +51,8 @@
          than the size of the config_autoBrightnessLevels array.
          This must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLcdBacklightValues">
-        <item>10</item>   <!--    0 -->
+        <item>3</item>    <!--    0 -->
+        <item>10</item>   <!--   32 -->
         <item>32</item>   <!--   64 -->
         <item>64</item>   <!--  128 -->
         <item>80</item>   <!--  170 -->
@@ -67,17 +69,17 @@
 
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
-    <integer name="config_screenBrightnessSettingMinimum">10</integer>
+    <integer name="config_screenBrightnessSettingMinimum">2</integer>
 
     <!-- Screen brightness used to dim the screen while dozing in a very low power state.
          May be less than the minimum allowed brightness setting
          that can be set by the user. -->
-    <integer name="config_screenBrightnessDoze">5</integer>
+    <integer name="config_screenBrightnessDoze">1</integer>
 
     <!-- Screen brightness used to dim the screen when the user activity
          timeout expires.  May be less than the minimum allowed brightness setting
          that can be set by the user. -->
-    <integer name="config_screenBrightnessDim">10</integer>
+    <integer name="config_screenBrightnessDim">3</integer>
 
     <!-- Minimum allowable screen brightness to use in a very dark room.
          This value sets the floor for the darkest possible auto-brightness
@@ -86,7 +88,7 @@
          some range of adjustment to dim the screen further than usual in very
          dark rooms. The contents of the screen must still be clearly visible
          in darkness (although they may not be visible in a bright room). -->
-    <integer name="config_screenBrightnessDark">5</integer>
+    <integer name="config_screenBrightnessDark">1</integer>
 
     <!-- Whether device supports double tap to wake -->
     <bool name="config_supportDoubleTapWake">false</bool>


### PR DESCRIPTION
Users using PE based on SODP have complained that the
minimum user settable brightness is still way too high for night.
Looking at:
sys/class/backlight/panel0-backlight/brightness
tells us that even at lowest brightness the brightness is still 160
which is indeed high for night usage.

So lets reduce the brightness even more.

Based on: 
https://github.com/sonyxperiadev/device-sony-akatsuki/commit/2a2d118e29f35a370f0109a1984f697fd6e6d242